### PR TITLE
Add badge_type_id as an attribute of an Athlete

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -247,6 +247,8 @@ class Athlete(LoadableEntity):
 
     email_language = Attribute(unicode, (SUMMARY,DETAILED)) #: The user's preferred lang/locale (e.g. en-US)
 
+    badge_type_id = Attribute(int) #: (undocumented)
+
     # A bunch more undocumented detailed-resolution attribs
     weight = Attribute(float, (DETAILED,), units=uh.kg) #: (undocumented, detailed-only)  Athlete's configured weight.
     max_heartrate = Attribute(float, (DETAILED,)) #: (undocumented, detailed-only) Athlete's configured max HR


### PR DESCRIPTION
The Strava API is returning an integer field called "badge_type_id" when I request my athlete details, which is generating a warning because this library is not aware of the attribute.

There is no API documentation at all for this attribute, so I'm not able to add any details about where it appears or what it means, sorry!
