### PR TITLE
Making docstring type hints match reality for get_segment_leaderboard()

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -788,8 +788,8 @@ class Client(object):
         :param page: (optional, strava default is 1) Page number of leaderboard to return, sorted by highest ranking leaders
         :type page: int
 
-        :return: An iterator of :class:`stravalib.model.SegmentLeaderboard`
-        :rtype: :class:`BatchedResultsIterator`
+        :return: The SegmentLeaderboard for the specified page (default: 1)
+        :rtype: :class:`stravalib.model.SegmentLeaderboard`
 
         """
         params = {}


### PR DESCRIPTION
One could argue that changing the functionality of this method to return an iterator would be the right thing to do, but for now, the docstring should at least match the fact that it returns a SegmentLeaderboard object for now.
