### PR TITLE
Adding get related activites functionality to client

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -674,6 +674,27 @@ class Client(object):
         return BatchedResultsIterator(entity=model.ActivityLap,
                                       bind_client=self,
                                       result_fetcher=result_fetcher)
+        
+    def get_related_activities(self, activity_id, limit=None):
+        """
+        Returns the activities that were matched as 'with this activity'.
+
+        http://strava.github.io/api/v3/activities/#get-related
+
+        :param activity_id: The activity for which to fetch related activities.
+        :type activity_id: int
+
+        :return: An iterator of :class:`stravalib.model.Activity` objects.
+        :rtype: :class:`BatchedResultsIterator`
+        """
+        result_fetcher = functools.partial(self.protocol.get,
+                                           '/activities/{id}/related',
+                                           id=activity_id)
+
+        return BatchedResultsIterator(entity=model.Activity,
+                                      bind_client=self,
+                                      result_fetcher=result_fetcher,
+                                      limit=limit)
 
     def get_gear(self, gear_id):
         """

--- a/stravalib/tests/functional/test_client.py
+++ b/stravalib/tests/functional/test_client.py
@@ -114,6 +114,17 @@ class ClientTest(FunctionalTestBase):
         # latlng stream
         self.assertIsInstance(streams['latlng'].data, list)
         self.assertIsInstance(streams['latlng'].data[0][0], float)
+        
+    def test_related_activities(self):
+        """
+        Test get_related_activities on an activity
+        """
+        activity_id = 152668627
+        activity = self.client.get_activity(activity_id)
+        related_activities = list(self.client.get_related_activities(activity_id))
+        
+        # Check the number of related_activities matches what activity would expect
+        self.assertEqual(len(related_activities), activity.athlete_count-1)
 
     def test_effort_streams(self):
         """


### PR DESCRIPTION
Adds http://strava.github.io/api/v3/activities/#get-related functionality
(Changelog Dec 29th 2014 entry)