### PR TITLE
fixes for upload_activity

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1310,9 +1310,9 @@ class ActivityUploader(object):
 
         """
         self.client = client
-        self.update_from_repsonse(response)
+        self.update_from_response(response)
 
-    def update_from_repsonse(self, response, raise_exc=True):
+    def update_from_response(self, response, raise_exc=True):
         """
         Updates internal state of object.
 
@@ -1359,7 +1359,7 @@ class ActivityUploader(object):
                                             upload_id=self.upload_id,
                                             check_for_errors=False)
 
-        self.update_from_repsonse(response)
+        self.update_from_response(response)
 
     def wait(self, timeout=None, poll_interval=1.0):
         """

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1323,11 +1323,11 @@ class ActivityUploader(object):
         :type raise_exc: bool
         :raise stravalib.exc.ActivityUploadFailed: If the response indicates an error and raise_exc is True.
         """
-        self.upload_id = response['id']
+        self.upload_id = response.get('id')
         self.external_id = response.get('external_id')
         self.activity_id = response.get('activity_id')
-        self.status = response['status']
-        self.error = response['error']
+        self.status = response.get('status')
+        self.error = response.get('error')
         if raise_exc:
             self.raise_for_error()
 

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -540,7 +540,7 @@ class Client(object):
         raw_activity = self.protocol.put('/activities/{activity_id}', **params)
         return model.Activity.deserialize(raw_activity, bind_client=self)
 
-    def upload_activity(self, activity_file, data_type, name=None,
+    def upload_activity(self, activity_file, data_type, name=None, description=None,
                         activity_type=None, private=None, external_id=None):
         """
         Uploads a GPS file (tcx, gpx) to create a new activity for current athlete.
@@ -554,6 +554,9 @@ class Client(object):
         :type data_type: str
 
         :param name: (optional) if not provided, will be populated using start date and location, if available
+        :type name: str
+
+        :param description: (optional) The description for the activity
         :type name: str
 
         :param activity_type: (optional) case-insensitive type of activity.
@@ -583,7 +586,9 @@ class Client(object):
 
         params = {'data_type': data_type}
         if name is not None:
-            params['activity_name'] = name
+            params['name'] = name
+        if description is not None:
+            params['description'] = description
         if activity_type is not None:
             if not activity_type.lower() in [t.lower() for t in model.Activity.TYPES]:
                 raise ValueError("Invalid activity type: {0}.  Possible values: {1!r}".format(activity_type, model.Activity.TYPES))


### PR DESCRIPTION
dlenski@772eb42 : The name of the activity should be in parameter `name`, not `activity_name`, and a `description` can be included too. (http://strava.github.io/api/v3/uploads/#post-file)

dlenski@70025d6 : The `upload_activity` response may not contain an `id` field if the response is `401 Unauthorized`