### PR TITLE
use .items() for python2/3 compatibility

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -261,7 +261,7 @@ class Client(object):
                   'state': state,
                   'country': country,
                   'sex': sex}
-        params = {k: v for (k, v) in params.iteritems() if v is not None}
+        params = {k: v for (k, v) in params.items() if v is not None}
         if weight is not None:
             params['weight'] = float(weight)
 


### PR DESCRIPTION
The update_athlete() method in client.py does not work with Python 3.x as 
iteritems() has been removed from Python 3.x.