### PR TITLE
Fix unicode string as name of class

### DIFF
--- a/stravalib/attributes.py
+++ b/stravalib/attributes.py
@@ -255,7 +255,7 @@ class EntityAttribute(Attribute):
 
     @type.setter
     def type(self, v):
-        if isinstance(v, (str, bytes)):
+        if isinstance(v, (str, bytes, unicode)):
             # Supporting lazy class referencing
             self._lazytype = v
         else:


### PR DESCRIPTION
There exists a list (tuple actually) of accepted types - str or bytes.
Lines like this:
    activity = EntityAttribute("Activity", (SUMMARY, DETAILED))
can be passed as unicode string, that will cause failure.

Adding unicode type to whitelist fix this case.