### PR TITLE
add "starred" property on SegmentExplorerResult

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -507,6 +507,7 @@ class SegmentExplorerResult(LoadableEntity):
     elev_difference = Attribute(float, units=uh.meters)  #: Total elevation difference over segment.
     distance = Attribute(float, units=uh.meters)  #: Distance of segment.
     points = Attribute(str)  #: Encoded Google polyline of points in segment
+    starred = Attribute(bool)  #: Whether this segment is starred by authenticated athlete
 
     @property
     def segment(self):


### PR DESCRIPTION
Addresses https://github.com/hozn/stravalib/issues/50
Logged warning: No such attribute starred on entity <SegmentExplorerResult id=None name='Mt Sanitas Trail Climb' resource_state=2>