### PR TITLE
Add new pr_count property.

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -705,6 +705,7 @@ class Activity(LoadableEntity):
     start_longitude = Attribute(float, (SUMMARY, DETAILED))  #: The start longitude
 
     achievement_count = Attribute(int, (SUMMARY, DETAILED))  #: How many achievements earned for the activity
+    pr_count = Attribute(int, (SUMMARY, DETAILED))  #: How many new personal records earned for the activity
     kudos_count = Attribute(int, (SUMMARY, DETAILED))  #: How many kudos received for activity
     comment_count = Attribute(int, (SUMMARY, DETAILED))  #: How many comments  for activity.
     athlete_count = Attribute(int, (SUMMARY, DETAILED))  #: How many other athlete's participated in activity


### PR DESCRIPTION
I started getting log noise like this:

WARNING:stravalib.model.Activity:No such attribute pr_count on entity <Activity id=784664167 name=u'Evening commute' resource_state=None>

Looks like this is a new property showing the number of new personal records earned?