### PR TITLE
Adding more info to ActivityUploader and handling errors

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1596,6 +1596,7 @@ class ActivityUploader(object):
 
         """
         self.client = client
+        self.response = response
         self.update_from_response(response)
 
     def update_from_response(self, response, raise_exc=True):

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1614,7 +1614,7 @@ class ActivityUploader(object):
         self.external_id = response.get('external_id')
         self.activity_id = response.get('activity_id')
         self.status = response.get('status')
-        self.error = response.get('error')
+        self.error = response.get('error') or response.get('errors')
         if raise_exc:
             self.raise_for_error()
 

--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1613,7 +1613,7 @@ class ActivityUploader(object):
         self.upload_id = response.get('id')
         self.external_id = response.get('external_id')
         self.activity_id = response.get('activity_id')
-        self.status = response.get('status')
+        self.status = response.get('status') or response.get('message')
         self.error = response.get('error') or response.get('errors')
         if raise_exc:
             self.raise_for_error()

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -176,8 +176,18 @@ class ApiV3(object):
             resp = raw.json()
 
         headers = raw.headers
-        resp.update(rate_limit=headers.get('x-ratelimit-limit'),
-                    rate_limit_usage=headers.get('x-ratelimit-usage'))
+        rate_limit = headers.get('x-ratelimit-limit')
+        if rate_limit:
+            short_term_limit, long_term_limit = [int(limit) for limit in rate_limit.split(',')]
+            resp.update(short_term_rate_limit=short_term_limit,
+                        long_term_rate_limit=long_term_limit)
+
+        rate_limit_usage = headers.get('x-ratelimit-usage')
+        if rate_limit_usage:
+            short_term_usage, long_term_usage = [int(limit) for limit in rate_limit_usage.split(',')]
+            resp.update(short_term_rate_limit_usage=short_term_usage,
+                        long_term_rate_limit_usage=long_term_usage)
+
 
         # At this stage we should assume that request was successful and we should invoke
         # our rate limiter.  (Note that this may need to be reviewed; some failures may

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -175,6 +175,7 @@ class ApiV3(object):
         else:
             resp = raw.json()
 
+        # see: http://strava.github.io/api/#access for rate limit info
         headers = raw.headers
         rate_limit = headers.get('x-ratelimit-limit')
         if rate_limit:

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -175,20 +175,9 @@ class ApiV3(object):
         else:
             resp = raw.json()
 
-        # see: http://strava.github.io/api/#access for rate limit info
-        headers = raw.headers
-        rate_limit = headers.get('x-ratelimit-limit')
-        if rate_limit:
-            short_term_limit, long_term_limit = [int(limit) for limit in rate_limit.split(',')]
-            resp.update(short_term_rate_limit=short_term_limit,
-                        long_term_rate_limit=long_term_limit)
-
-        rate_limit_usage = headers.get('x-ratelimit-usage')
-        if rate_limit_usage:
-            short_term_usage, long_term_usage = [int(limit) for limit in rate_limit_usage.split(',')]
-            resp.update(short_term_rate_limit_usage=short_term_usage,
-                        long_term_rate_limit_usage=long_term_usage)
-
+        # TODO: We should parse the response to get the rate limit details and
+        # update our rate limiter.
+        # see: http://strava.github.io/api/#access
 
         # At this stage we should assume that request was successful and we should invoke
         # our rate limiter.  (Note that this may need to be reviewed; some failures may

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -175,11 +175,9 @@ class ApiV3(object):
         else:
             resp = raw.json()
 
-        resp.update(status_code=raw.status_code, headers=raw.headers)
-
-        # TODO: We should parse the response to get the rate limit details and
-        # update our rate limiter.
-        # see: http://strava.github.io/api/#access
+        headers = raw.headers
+        resp.update(rate_limit=headers.get('x-ratelimit-limit'),
+                    rate_limit_usage=headers.get('x-ratelimit-usage'))
 
         # At this stage we should assume that request was successful and we should invoke
         # our rate limiter.  (Note that this may need to be reviewed; some failures may

--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -175,6 +175,8 @@ class ApiV3(object):
         else:
             resp = raw.json()
 
+        resp.update(status_code=raw.status_code, headers=raw.headers)
+
         # TODO: We should parse the response to get the rate limit details and
         # update our rate limiter.
         # see: http://strava.github.io/api/#access


### PR DESCRIPTION
I was trying to upload a `tcx.gz` file to Strava, but was hitting timeout issues when waiting for the activity to finish processing. However, the initial request actually failed with a 400. This wasn't captured by `upload_activity` because Strava returned a JSON payload in the format: 

```
{u'errors': [{u'code': u'invalid encoding',
              u'field': u'gzip',
              u'resource': u'upload'}],
 u'message': u'Bad Request',
 }
```

Both `errors` and `message` aren't in the API documentation. Because `errors`, and not `error` was returned, `upload_activity` did not raise an exception.

I also am saving that response info in `ActivityUploader` instances. This allows a consumer to inspect all of the data returned by Strava.