### PR TITLE
More rate limit improvements

### DIFF
--- a/stravalib/tests/functional/test_client_rate_limiter.py
+++ b/stravalib/tests/functional/test_client_rate_limiter.py
@@ -1,13 +1,11 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
-from stravalib import model, attributes, exc, unithelper as uh
-from stravalib.client import Client
-from stravalib.util.limiter import DefaultRateLimiter
-from stravalib.util.limiter import XRateLimitRule
-from stravalib.tests.functional import FunctionalTestBase
 
 import time
-import datetime
-import requests
+
+from stravalib import exc
+from stravalib.tests.functional import FunctionalTestBase
+from stravalib.util.limiter import DefaultRateLimiter
+from stravalib.util.limiter import XRateLimitRule
 
 
 class ClientDefaultRateLimiterTest(FunctionalTestBase):

--- a/stravalib/tests/functional/test_client_rate_limiter.py
+++ b/stravalib/tests/functional/test_client_rate_limiter.py
@@ -18,8 +18,8 @@ class ClientDefaultRateLimiterTest(FunctionalTestBase):
         # setup 'short' limit for testing
         self.client.protocol.rate_limiter.rules = []
         self.client.protocol.rate_limiter.rules.append(XRateLimitRule(
-            {'short': {'usageFieldIndex': 0, 'usage': 0, 'limit': 600,
-                       'time': 5, 'lastExceeded': None}}))
+            {'short': {'usage': 0, 'limit': 600, 'time': 5, 'lastExceeded': None},
+             'long': {'usage': 0, 'limit': 30000, 'time': 5, 'lastExceeded': None}}))
 
         # interact with api to get the limits
         self.client.get_athlete()

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -95,4 +95,6 @@ class SleepingRateLimitRuleTest(TestBase):
         """Should wait until end of period when limit is reached, regardless priority"""
         rule = SleepingRateLimitRule(short_limit=10, long_limit=100)
         self.assertEqual(42, rule._get_wait_time(10, 10, 42, 1000))
+        self.assertEqual(42, rule._get_wait_time(1234, 10, 42, 1000))
         self.assertEqual(21, rule._get_wait_time(10, 100, 42, 21))
+        self.assertEqual(21, rule._get_wait_time(10, 1234, 42, 21))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -2,7 +2,7 @@ import arrow
 
 from stravalib.tests import TestBase
 from stravalib.util.limiter import get_rates_from_response_headers, XRateLimitRule, get_seconds_until_next_quarter, \
-    get_seconds_until_next_day
+    get_seconds_until_next_day, SleepingRateLimitRule
 
 test_response = {'Status': '404 Not Found', 'X-Request-Id': 'a1a4a4973962ffa7e0f18d7c485fe741',
                  'Content-Encoding': 'gzip', 'Content-Length': '104', 'Connection': 'keep-alive',
@@ -62,3 +62,12 @@ class XRateLimitRuleTest(TestBase):
         rule(test_response_no_rates)
         self.assertEqual(0, rule.rate_limits['short']['usage'])
         self.assertEqual(0, rule.rate_limits['long']['usage'])
+
+
+class SleepingRateLimitRuleTest(TestBase):
+    def setUp(self):
+        self.test_response = test_response.copy()
+
+    def test_get_wait_time_high_priority(self):
+        """Should never sleep/wait for high priority requests"""
+        self.assertEqual(0, SleepingRateLimitRule()._get_wait_time(42, 42, 60, 3600))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -69,5 +69,11 @@ class SleepingRateLimitRuleTest(TestBase):
         self.test_response = test_response.copy()
 
     def test_get_wait_time_high_priority(self):
-        """Should never sleep/wait for high priority requests"""
+        """Should never sleep/wait after high priority requests"""
         self.assertEqual(0, SleepingRateLimitRule()._get_wait_time(42, 42, 60, 3600))
+
+    def test_get_wait_time_medium_priority(self):
+        """Should return number of seconds to next short limit divided by number of remaining requests
+        for that period"""
+        rule = SleepingRateLimitRule(priority='medium', short_limit=10)
+        self.assertEqual(1, rule._get_wait_time(1, 1, 9, 1000))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -75,5 +75,13 @@ class SleepingRateLimitRuleTest(TestBase):
     def test_get_wait_time_medium_priority(self):
         """Should return number of seconds to next short limit divided by number of remaining requests
         for that period"""
-        rule = SleepingRateLimitRule(priority='medium', short_limit=10)
-        self.assertEqual(1, rule._get_wait_time(1, 1, 9, 1000))
+        rule = SleepingRateLimitRule(priority='medium', short_limit=11)
+        self.assertEqual(1, rule._get_wait_time(1, 1, 10, 1000))
+        self.assertEqual(0.5, rule._get_wait_time(1, 1, 5, 1000))
+
+    def test_get_wait_time_low_priority(self):
+        """Should return number of seconds to next long limit divided by number of remaining requests
+        for that period"""
+        rule = SleepingRateLimitRule(priority='low', long_limit=11)
+        self.assertEqual(1, rule._get_wait_time(1, 1, 1, 10))
+        self.assertEqual(0.5, rule._get_wait_time(1, 1, 1, 5))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -105,3 +105,20 @@ class SleepingRateLimitRuleTest(TestBase):
         rule(self.test_response)
         self.assertEqual(10000, rule.short_limit)
         self.assertEqual(1000000, rule.long_limit)
+
+    def test_invocation_changed_limits(self):
+        """Should update limits in case of changes, depending on limit enforcement"""
+        self.test_response['X-RateLimit-Usage'] = '0, 0'
+        self.test_response['X-RateLimit-Limit'] = '600, 30000'
+
+        # without limit enforcement (default)
+        rule = SleepingRateLimitRule()
+        rule(self.test_response)
+        self.assertEqual(600, rule.short_limit)
+        self.assertEqual(30000, rule.long_limit)
+
+        # with limit enforcement
+        rule = SleepingRateLimitRule(force_limits=True)
+        rule(self.test_response)
+        self.assertEqual(10000, rule.short_limit)
+        self.assertEqual(1000000, rule.long_limit)

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -85,3 +85,9 @@ class SleepingRateLimitRuleTest(TestBase):
         rule = SleepingRateLimitRule(priority='low', long_limit=11)
         self.assertEqual(1, rule._get_wait_time(1, 1, 1, 10))
         self.assertEqual(0.5, rule._get_wait_time(1, 1, 1, 5))
+
+    def test_get_wait_time_limit_reached(self):
+        """Should wait until end of period when limit is reached, regardless priority"""
+        rule = SleepingRateLimitRule(short_limit=10, long_limit=100)
+        self.assertEqual(42, rule._get_wait_time(10, 10, 42, 1000))
+        self.assertEqual(21, rule._get_wait_time(10, 100, 42, 21))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -37,10 +37,10 @@ class LimiterTest(TestBase):
 
     def test_get_seconds_until_next_quarter(self):
         """Should return number of seconds to next quarter of an hour"""
-        self.assertEqual(60, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 14, 0, 0)))
-        self.assertEqual(60, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 0, 0)))
-        self.assertEqual(1, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 59, 999999)))
-        self.assertEqual(900, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 0, 0, 1)))
+        self.assertEqual(59, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 14, 0, 0)))
+        self.assertEqual(59, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 0, 0)))
+        self.assertEqual(0, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 59, 999999)))
+        self.assertEqual(899, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 0, 0, 1)))
 
     def test_get_seconds_until_next_day(self):
         """Should return the number of seconds until next day"""

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -1,7 +1,8 @@
 import arrow
 
 from stravalib.tests import TestBase
-from stravalib.util.limiter import get_rates_from_response_headers, XRateLimitRule, get_seconds_until_next_quarter
+from stravalib.util.limiter import get_rates_from_response_headers, XRateLimitRule, get_seconds_until_next_quarter, \
+    get_seconds_until_next_day
 
 test_response = {'Status': '404 Not Found', 'X-Request-Id': 'a1a4a4973962ffa7e0f18d7c485fe741',
                  'Content-Encoding': 'gzip', 'Content-Length': '104', 'Connection': 'keep-alive',
@@ -40,6 +41,11 @@ class LimiterTest(TestBase):
         self.assertEqual(60, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 0, 0)))
         self.assertEqual(1, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 59, 999999)))
         self.assertEqual(900, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 0, 0, 1)))
+
+    def test_get_seconds_until_next_day(self):
+        """Should return the number of seconds until next day"""
+        self.assertEqual(59, get_seconds_until_next_day(arrow.get(2017, 11, 1, 23, 59, 0, 0)))
+        self.assertEqual(86399, get_seconds_until_next_day(arrow.get(2017, 11, 1, 0, 0, 0, 0)))
 
 
 class XRateLimitRuleTest(TestBase):

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -1,0 +1,33 @@
+from stravalib.tests import TestBase
+from stravalib.util.limiter import get_rates_from_response_headers
+
+test_response = {'Status': '404 Not Found', 'X-Request-Id': 'a1a4a4973962ffa7e0f18d7c485fe741',
+                 'Content-Encoding': 'gzip', 'Content-Length': '104', 'Connection': 'keep-alive',
+                 'X-RateLimit-Limit': '600,30000', 'X-UA-Compatible': 'IE=Edge,chrome=1',
+                 'Cache-Control': 'no-cache, private', 'Date': 'Tue, 14 Nov 2017 11:29:15 GMT',
+                 'X-FRAME-OPTIONS': 'DENY', 'Content-Type': 'application/json; charset=UTF-8',
+                 'X-RateLimit-Usage': '4,67'}
+
+test_response_no_rates = {'Status': '200 OK', 'X-Request-Id': 'd465159561420f6e0239dc24429a7cf3',
+                          'Content-Encoding': 'gzip', 'Content-Length': '371', 'Connection': 'keep-alive',
+                          'X-UA-Compatible': 'IE=Edge,chrome=1', 'Cache-Control': 'max-age=0, private, must-revalidate',
+                          'Date': 'Tue, 14 Nov 2017 13:19:31 GMT', 'X-FRAME-OPTIONS': 'DENY',
+                          'Content-Type': 'application/json; charset=UTF-8'}
+
+
+class LimiterTest(TestBase):
+    def test_get_rates_from_response_headers(self):
+        """Should return namedtuple with rates"""
+        request_rates = get_rates_from_response_headers(test_response)
+        self.assertEqual(600, request_rates.short_limit)
+        self.assertEqual(30000, request_rates.long_limit)
+        self.assertEqual(4, request_rates.short_usage)
+        self.assertEqual(67, request_rates.long_usage)
+
+    def test_get_rates_from_response_headers_missing_rates(self):
+        """Should return namedtuple with None values for rates in case of missing rates in headers"""
+        request_rates = get_rates_from_response_headers(test_response_no_rates)
+        self.assertIsNone(request_rates.short_limit)
+        self.assertIsNone(request_rates.long_limit)
+        self.assertIsNone(request_rates.short_usage)
+        self.assertIsNone(request_rates.long_usage)

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -94,3 +94,14 @@ class SleepingRateLimitRuleTest(TestBase):
         self.assertEqual(42, rule._get_wait_time(1234, 10, 42, 1000))
         self.assertEqual(21, rule._get_wait_time(10, 100, 42, 21))
         self.assertEqual(21, rule._get_wait_time(10, 1234, 42, 21))
+
+    def test_invocation_unchanged_limits(self):
+        """Should not update limits if these don't change"""
+        self.test_response['X-RateLimit-Usage'] = '0, 0'
+        self.test_response['X-RateLimit-Limit'] = '10000, 1000000'
+        rule = SleepingRateLimitRule()
+        self.assertEqual(10000, rule.short_limit)
+        self.assertEqual(1000000, rule.long_limit)
+        rule(self.test_response)
+        self.assertEqual(10000, rule.short_limit)
+        self.assertEqual(1000000, rule.long_limit)

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -68,6 +68,11 @@ class SleepingRateLimitRuleTest(TestBase):
     def setUp(self):
         self.test_response = test_response.copy()
 
+    def test_invalid_priority(self):
+        """Should raise ValueError in case of invalid priority"""
+        with self.assertRaises(ValueError):
+            SleepingRateLimitRule(priority='foobar')
+
     def test_get_wait_time_high_priority(self):
         """Should never sleep/wait after high priority requests"""
         self.assertEqual(0, SleepingRateLimitRule()._get_wait_time(42, 42, 60, 3600))

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -29,11 +29,7 @@ class LimiterTest(TestBase):
 
     def test_get_rates_from_response_headers_missing_rates(self):
         """Should return namedtuple with None values for rates in case of missing rates in headers"""
-        request_rates = get_rates_from_response_headers(test_response_no_rates)
-        self.assertIsNone(request_rates.short_limit)
-        self.assertIsNone(request_rates.long_limit)
-        self.assertIsNone(request_rates.short_usage)
-        self.assertIsNone(request_rates.long_usage)
+        self.assertIsNone(get_rates_from_response_headers(test_response_no_rates))
 
     def test_get_seconds_until_next_quarter(self):
         """Should return number of seconds to next quarter of an hour"""

--- a/stravalib/tests/unit/test_limiter.py
+++ b/stravalib/tests/unit/test_limiter.py
@@ -1,5 +1,7 @@
+import arrow
+
 from stravalib.tests import TestBase
-from stravalib.util.limiter import get_rates_from_response_headers, XRateLimitRule
+from stravalib.util.limiter import get_rates_from_response_headers, XRateLimitRule, get_seconds_until_next_quarter
 
 test_response = {'Status': '404 Not Found', 'X-Request-Id': 'a1a4a4973962ffa7e0f18d7c485fe741',
                  'Content-Encoding': 'gzip', 'Content-Length': '104', 'Connection': 'keep-alive',
@@ -31,6 +33,13 @@ class LimiterTest(TestBase):
         self.assertIsNone(request_rates.long_limit)
         self.assertIsNone(request_rates.short_usage)
         self.assertIsNone(request_rates.long_usage)
+
+    def test_get_seconds_until_next_quarter(self):
+        """Should return number of seconds to next quarter of an hour"""
+        self.assertEqual(60, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 14, 0, 0)))
+        self.assertEqual(60, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 0, 0)))
+        self.assertEqual(1, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 59, 59, 999999)))
+        self.assertEqual(900, get_seconds_until_next_quarter(arrow.get(2017, 11, 1, 17, 0, 0, 1)))
 
 
 class XRateLimitRuleTest(TestBase):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -79,22 +79,22 @@ class XRateLimitRule(object):
     def __call__(self, response_headers):
         self._updateUsage(response_headers)
         
-        for limitName, limit in self.rate_limits.items():
-            self._checkLimitTimeInvalid(limitName, limit)
-            self._checkLimitRates(limitName, limit)
+        for limit in self.rate_limits.values():
+            self._checkLimitTimeInvalid(limit)
+            self._checkLimitRates(limit)
             
     def _updateUsage(self, response_headers):
         rates = get_rates_from_response_headers(response_headers)
         self.rate_limits['short']['usage'] = rates.short_usage or self.rate_limits['short']['usage']
         self.rate_limits['long']['usage'] = rates.long_usage or self.rate_limits['long']['usage']
 
-    def _checkLimitRates(self, limitName, limit):
+    def _checkLimitRates(self, limit):
         if (limit['usage'] >= limit['limit']):
             self.log.debug("Rate limit of {0} reached.".format(limit['limit']))
             limit['lastExceeded'] = datetime.now()
             self._raiseRateLimitException(limit['limit'], limit['time'])
 
-    def _checkLimitTimeInvalid(self, limitName, limit):
+    def _checkLimitTimeInvalid(self, limit):
         self.limit_time_invalid = 0
         if (limit['lastExceeded'] is not None):
             delta = (datetime.now() - limit['lastExceeded']).total_seconds()

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -112,11 +112,17 @@ class XRateLimitRule(object):
 
 
 class SleepingRateLimitRule(object):
-    def __init__(self, priority='high'):
+    def __init__(self, priority='high', short_limit=10000, long_limit=1000000, force_limits=False):
         self.log = logging.getLogger('{0.__module__}.{0.__name__}'.format(self.__class__))
         self.priority = priority
+        self.short_limit = short_limit
+        self.long_limit = long_limit
+        self.force_limits = force_limits
 
     def _get_wait_time(self, short_usage, long_usage, seconds_until_short_limit, seconds_until_long_limit):
+        if self.priority == 'medium':
+            return (self.short_limit - short_usage) / seconds_until_short_limit
+
         return 0
 
 

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -76,8 +76,8 @@ class XRateLimitRule(object):
     def limit_timeout(self):
         return self.limit_time_invalid
 
-    def __call__(self, kwargs):
-        self._updateUsage(self.rate_limits, kwargs)
+    def __call__(self, response_headers):
+        self._updateUsage(self.rate_limits, response_headers)
         
         for limitName, limit in self.rate_limits.items():
             self._checkLimitTimeInvalid(limitName, limit)

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -58,6 +58,10 @@ def get_seconds_until_next_quarter(now=arrow.utcnow()):
     return 900 - (now - now.replace(minute=(now.minute // 15) * 15, second=0, microsecond=0)).seconds
 
 
+def get_seconds_until_next_day(now=arrow.utcnow()):
+    return (now.ceil('day') - now).seconds
+
+
 class SleepingRateLimitRule(object):
     pass
 

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -77,16 +77,16 @@ class XRateLimitRule(object):
         return self.limit_time_invalid
 
     def __call__(self, response_headers):
-        self._updateUsage(self.rate_limits, response_headers)
+        self._updateUsage(response_headers)
         
         for limitName, limit in self.rate_limits.items():
             self._checkLimitTimeInvalid(limitName, limit)
             self._checkLimitRates(limitName, limit)
             
-    def _updateUsage(self, limits, response_headers):
+    def _updateUsage(self, response_headers):
         rates = get_rates_from_response_headers(response_headers)
-        limits['short']['usage'] = rates.short_usage or limits['short']['usage']
-        limits['long']['usage'] = rates.long_usage or limits['long']['usage']
+        self.rate_limits['short']['usage'] = rates.short_usage or self.rate_limits['short']['usage']
+        self.rate_limits['long']['usage'] = rates.long_usage or self.rate_limits['long']['usage']
 
     def _checkLimitRates(self, limitName, limit):
         if (limit['usage'] >= limit['limit']):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -139,6 +139,9 @@ class SleepingRateLimitRule(object):
         if rates:
             time.sleep(self._get_wait_time(rates.short_usage, rates.long_usage,
                                            get_seconds_until_next_quarter(), get_seconds_until_next_day()))
+            if not self.force_limits:
+                self.short_limit = rates.short_limit
+                self.long_limit = rates.long_limit
 
 
 class RateLimitRule(object):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -133,6 +133,13 @@ class SleepingRateLimitRule(object):
         elif self.priority == 'low':
             return seconds_until_long_limit / (self.long_limit - long_usage)
 
+    def __call__(self, response_headers):
+        rates = get_rates_from_response_headers(response_headers)
+
+        if rates:
+            time.sleep(self._get_wait_time(rates.short_usage, rates.long_usage,
+                                           get_seconds_until_next_quarter(), get_seconds_until_next_day()))
+
 
 class RateLimitRule(object):
 

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -17,10 +17,13 @@ From the Strava docs:
   half the day.
 """
 from __future__ import division, absolute_import, print_function, unicode_literals
-import time
-import logging
+
 import collections
+import logging
+import time
 from datetime import datetime, timedelta
+
+import arrow
 
 from stravalib import exc
 
@@ -49,6 +52,14 @@ def get_rates_from_response_headers(headers):
 
     return RequestRate(short_usage=usage_rates[0], long_usage=usage_rates[1],
                        short_limit=limit_rates[0], long_limit=limit_rates[1])
+
+
+def get_seconds_until_next_quarter(now=arrow.utcnow()):
+    return 900 - (now - now.replace(minute=(now.minute // 15) * 15, second=0, microsecond=0)).seconds
+
+
+class SleepingRateLimitRule(object):
+    pass
 
 
 class XRateLimitRule(object):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -51,20 +51,6 @@ def get_rates_from_response_headers(headers):
                        short_limit=limit_rates[0], long_limit=limit_rates[1])
 
 
-class RateLimiter(object):
-
-    def __init__(self):
-        self.log = logging.getLogger('{0.__module__}.{0.__name__}'.format(self.__class__))
-        self.rules = []
-
-    def __call__(self, args):
-        """
-        Register another request is being issued.
-        """
-        for r in self.rules:
-            r(args)
-
-
 class XRateLimitRule(object):
     
     def __init__(self, limits):
@@ -150,6 +136,20 @@ class RateLimitRule(object):
                     self.log.debug("Rate limit triggered; sleeping for {0}".format(sleeptime))
                     time.sleep(sleeptime)
         self.tab.append(datetime.now())
+
+
+class RateLimiter(object):
+
+    def __init__(self):
+        self.log = logging.getLogger('{0.__module__}.{0.__name__}'.format(self.__class__))
+        self.rules = []
+
+    def __call__(self, args):
+        """
+        Register another request is being issued.
+        """
+        for r in self.rules:
+            r(args)
 
 
 class DefaultRateLimiter(RateLimiter):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -120,10 +120,12 @@ class SleepingRateLimitRule(object):
         self.force_limits = force_limits
 
     def _get_wait_time(self, short_usage, long_usage, seconds_until_short_limit, seconds_until_long_limit):
-        if self.priority == 'medium':
-            return (self.short_limit - short_usage) / seconds_until_short_limit
-
-        return 0
+        if self.priority == 'high':
+            return 0
+        elif self.priority == 'medium':
+            return seconds_until_short_limit / (self.short_limit - short_usage)
+        elif self.priority == 'low':
+            return seconds_until_long_limit / (self.long_limit - long_usage)
 
 
 class RateLimitRule(object):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -55,7 +55,7 @@ def get_rates_from_response_headers(headers):
 
 
 def get_seconds_until_next_quarter(now=arrow.utcnow()):
-    return 900 - (now - now.replace(minute=(now.minute // 15) * 15, second=0, microsecond=0)).seconds
+    return 899 - (now - now.replace(minute=(now.minute // 15) * 15, second=0, microsecond=0)).seconds
 
 
 def get_seconds_until_next_day(now=arrow.utcnow()):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -120,6 +120,11 @@ class SleepingRateLimitRule(object):
         self.force_limits = force_limits
 
     def _get_wait_time(self, short_usage, long_usage, seconds_until_short_limit, seconds_until_long_limit):
+        if long_usage >= self.long_limit:
+            return seconds_until_long_limit
+        elif short_usage >= self.short_limit:
+            return seconds_until_short_limit
+
         if self.priority == 'high':
             return 0
         elif self.priority == 'medium':

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -113,6 +113,9 @@ class XRateLimitRule(object):
 
 class SleepingRateLimitRule(object):
     def __init__(self, priority='high', short_limit=10000, long_limit=1000000, force_limits=False):
+        if priority not in ['low', 'medium', 'high']:
+            raise ValueError('Invalid priority "{0}", expecting one of "low", "medium" or "high"'.format(priority))
+
         self.log = logging.getLogger('{0.__module__}.{0.__name__}'.format(self.__class__))
         self.priority = priority
         self.short_limit = short_limit

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -159,8 +159,10 @@ class SleepingRateLimitRule(object):
 
     def _get_wait_time(self, short_usage, long_usage, seconds_until_short_limit, seconds_until_long_limit):
         if long_usage >= self.long_limit:
+            self.log.warning('Long term API rate limit exceeded')
             return seconds_until_long_limit
         elif short_usage >= self.short_limit:
+            self.log.warning('Short term API rate limit exceeded')
             return seconds_until_short_limit
 
         if self.priority == 'high':

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -32,6 +32,24 @@ def total_seconds(td):
     return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
 
 
+RequestRate = collections.namedtuple('RequestRate', ['short_usage', 'long_usage', 'short_limit', 'long_limit'])
+
+
+def get_rates_from_response_headers(headers):
+    try:
+        usage_rates = map(int, headers['X-RateLimit-Usage'].split(','))
+    except KeyError:
+        usage_rates = (None, None)
+
+    try:
+        limit_rates = map(int, headers['X-RateLimit-Limit'].split(','))
+    except KeyError:
+        limit_rates = (None, None)
+
+    return RequestRate(short_usage=usage_rates[0], long_usage=usage_rates[1],
+                       short_limit=limit_rates[0], long_limit=limit_rates[1])
+
+
 class RateLimiter(object):
 
     def __init__(self):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -83,14 +83,10 @@ class XRateLimitRule(object):
             self._checkLimitTimeInvalid(limitName, limit)
             self._checkLimitRates(limitName, limit)
             
-    def _updateUsage(self, limits, kwargs):
-        usageRates = kwargs.get('X-RateLimit-Usage').split(',')
-
-        # for the standard rules this will map like this
-        #  limits['short']['usage'] = int(usageRates[0])
-        #  limits['long']['usage'] = int(usageRates[1])
-        for limit in limits.values():
-            limit['usage'] = int(usageRates[limit['usageFieldIndex']])
+    def _updateUsage(self, limits, response_headers):
+        rates = get_rates_from_response_headers(response_headers)
+        limits['short']['usage'] = rates.short_usage or limits['short']['usage']
+        limits['long']['usage'] = rates.long_usage or limits['long']['usage']
 
     def _checkLimitRates(self, limitName, limit):
         if (limit['usage'] >= limit['limit']):

--- a/stravalib/util/limiter.py
+++ b/stravalib/util/limiter.py
@@ -62,10 +62,6 @@ def get_seconds_until_next_day(now=arrow.utcnow()):
     return (now.ceil('day') - now).seconds
 
 
-class SleepingRateLimitRule(object):
-    pass
-
-
 class XRateLimitRule(object):
     
     def __init__(self, limits):
@@ -113,6 +109,15 @@ class XRateLimitRule(object):
     def _raise_rate_limit_timeout(self, timeout, limit_rate):
         raise exc.RateLimitTimeout("Rate limit of {0} exceeded. Try again in {1} seconds."
                                    .format(limit_rate, timeout))
+
+
+class SleepingRateLimitRule(object):
+    def __init__(self, priority='high'):
+        self.log = logging.getLogger('{0.__module__}.{0.__name__}'.format(self.__class__))
+        self.priority = priority
+
+    def _get_wait_time(self, short_usage, long_usage, seconds_until_short_limit, seconds_until_long_limit):
+        return 0
 
 
 class RateLimitRule(object):


### PR DESCRIPTION
Introducing a new rate limit rule that uses feedback from the Strava API about actual limit usage. It uses variable cool-down periods after each response processed by the client. The cool-down periods depend on the number of request left in the current period, and the priority given to the rule. There's no need to initialize this rule with explicit limits, it will get these from the API responses as well.