### PR TITLE
Prevent AttributeError when ActivityUploader has no error

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1643,6 +1643,8 @@ class ActivityUploader(object):
         elif response.get('errors'):
             # This appears to be an undocumented API; ths is a bit of a hack for now.
             self.error = str(response.get('errors'))
+        else:
+            self.error = None
 
         if raise_exc:
             self.raise_for_error()


### PR DESCRIPTION
If there are no errors in the upload response, raise_for_exc raises AttributeError.