### PR TITLE
Add RunningRace model and expose get_running_race(s).

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -1338,6 +1338,44 @@ class Client(object):
 
         # Pack streams into dictionary
         return {i.type: i for i in streams}
+    
+    def get_running_race(self, race_id):
+        """
+        Gets a running race for a given identifier.t
+
+        http://strava.github.io/api/v3/running_races/#list
+
+        :param race_id: id for the race
+
+        :rtype: :class:`stravalib.model.RunningRace`
+        """        
+        raw = self.protocol.get('/running_races/{id}', id=race_id)
+        return model.RunningRace.deserialize(raw, bind_client=self)
+    
+    
+    def get_running_races(self, year=None):
+        """
+        Gets a running races for a given year.
+
+        http://strava.github.io/api/v3/running_races/#list
+
+        :param year: year for the races (default current)
+        
+        :return: An iterator of :class:`stravalib.model.RunningRace` objects.
+        :rtype: :class:`BatchedResultsIterator`
+        """
+        if year is None:
+            year = datetime.datetime.now().year
+    
+        params = {"year": year}
+
+        result_fetcher = functools.partial(self.protocol.get,
+                                           '/running_races',
+                                           **params)
+
+        return BatchedResultsIterator(entity=model.RunningRace, bind_client=self,
+                                      result_fetcher=result_fetcher)
+        
 
     def get_routes(self, athlete_id=None, limit=None):
         """

--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -333,6 +333,10 @@ class Athlete(LoadableEntity):
 
     sample_race_distance = Attribute(int, (DETAILED,))  # (undocumented, detailed-only)
     sample_race_time = Attribute(int, (DETAILED,))  # (undocumented, detailed-only)
+    
+    membership = Attribute(six.text_type, (SUMMARY, DETAILED))  #: (undocumented, club members only) String indicating the membership type of club
+    admin = Attribute(bool, (SUMMARY, DETAILED))  #: (undocumented, club members only) Flag indicating whether member is an admin of club
+    owner = Attribute(bool, (SUMMARY, DETAILED))  #: (undocumented, club members only) Flag indicating whether member is owner of club
 
     _friends = None
     _followers = None
@@ -1052,6 +1056,24 @@ class Stream(LoadableEntity):
         return '<Stream type={} resolution={} original_size={}>'.format(self.type,
                                                                         self.resolution,
                                                                         self.original_size,)
+class RunningRace(LoadableEntity):
+    """
+    Represents a RunningRace.
+    """
+    name = Attribute(six.text_type, (SUMMARY, DETAILED))  #: Name of the race.
+    id = Attribute(int) #: The unique identifier of this race. 
+    running_race_type = Attribute(int) #: Type of race
+    distance = Attribute(float, (SUMMARY, DETAILED), units=uh.meters) #: Distance for race in meters.
+    start_date_local = TimestampAttribute((SUMMARY, DETAILED), tzinfo=None)  #: :class:`datetime.datetime` when race was started local
+    city = Attribute(six.text_type, (DETAILED, ))  #: City the race is taking place in    
+    state = Attribute(six.text_type, (DETAILED, ))  #: State the race is taking place in    
+    country = Attribute(six.text_type, (DETAILED, ))  #: Country the race is taking place in
+    description = Attribute(six.text_type, (SUMMARY, DETAILED,))  #: Description of the route.
+    route_ids = Attribute(list) #: Set of routes that cover this race's course
+    measurement_preference = Attribute(six.text_type, (DETAILED,))  #: (detailed-only) How race prefers to see measurements (i.e. "feet" (or what "meters"?))
+    url = Attribute(six.text_type, (SUMMARY, DETAILED))  #: vanity race URL slug
+    website_url = Attribute(six.text_type, (SUMMARY, DETAILED))  #: race's website
+    status = Attribute(six.text_type, (SUMMARY, DETAILED))  #: (undocumented attribute)
 
 
 class Route(LoadableEntity):


### PR DESCRIPTION
This PR adds the RunningRace class and exposes two get functions:

- client.get_running_races(year)
- client.get_running_race(race_id)

For the first method the year defaults to the current year if empty.

See Strava API here:
https://developers.strava.com/docs/reference/#api-RunningRaces

Also while retrieving club members ```get_club_members(club_id=123)```. I noticed that I got some warnings on three attributes (membership, owner and admin) that are not part of the Athlete class. So I added these to the class too.

Let me know if you have any feedback.
