### PR TITLE
refresh_token and expires_at set to None if none are returned

### DIFF
--- a/stravalib/protocol.py
+++ b/stravalib/protocol.py
@@ -128,8 +128,8 @@ class ApiV3(object):
                                  method='POST')
         access_info = dict()
         access_info['access_token'] = response['access_token']
-        access_info['refresh_token'] = response['refresh_token']
-        access_info['expires_at'] = response['expires_at']
+        access_info['refresh_token'] = response.get('refresh_token', None)
+        access_info['expires_at'] = response.get('expires_at', None)
         self.access_token = response['access_token']
 
         return access_info


### PR DESCRIPTION
Hi there!

First of all, I love this library - thank you for putting it together!

I first started using stravalib over a year ago, before Strava added refresh tokens, and I know straight up access tokens are to be deprecated but for whatever reason (and maybe this is just the case because I first authorized my personal Strava account a couple of years ago) I am not returned a refresh token, just an authorization token so because of that I was getting a key error whenever I executed exchange_code_for_token. A quick get() with a None default solved the problem.

Let me know what you think!

All the best,
Keiron