### PR TITLE
Fix typo in get_activity_photos (kudos --> photos)

### DIFF
--- a/stravalib/client.py
+++ b/stravalib/client.py
@@ -795,7 +795,7 @@ class Client(object):
 
         http://strava.github.io/api/v3/photos/
 
-        :param activity_id: The activity for which to fetch kudos.
+        :param activity_id: The activity for which to fetch photos.
         :type activity_id: int
 
         :param size: the requested size of the activity's photos. URLs for the photos will be returned that best match


### PR DESCRIPTION
See https://pythonhosted.org/stravalib/api.html?highlight=kudos#stravalib.client.Client.get_activity_photos

Sorry for the super minor PR - feel free to close this and just include the change in your next commit if you want.