### PR TITLE
Make to_dict() include attributes of parent classes

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -44,10 +44,11 @@ class BaseEntity(object):
         :rtype: Dict[str, Any]
         """
         d = {}
-        for attrname, attr in self.__class__.__dict__.items():
-            if isinstance(attr, Attribute):
-                value = getattr(self, attrname)
-                d[attrname] = attr.marshal(value)
+        for cls in self.__class__.__mro__:
+            for attrname, attr in cls.__dict__.items():
+                if attrname not in d and isinstance(attr, Attribute):
+                    value = getattr(self, attrname)
+                    d[attrname] = attr.marshal(value)
         return d
 
     def from_dict(self, d):


### PR DESCRIPTION
Before this change `to_dict()` would only return values that were defined on the
local class.

For example, `Bike.to_dict()` would return a dict with a single `frame_type` key
since it's the only `Attribute` defined on the class. The rest of the
attributes are defined on the parent classes (`Gear`, `IdentifiableEntity`, etc.)

This commit makes `to_dict()` also look for `Attributes` defined on parent
classes and includes them in the output as well.