### PR TITLE
Fixes IndexErrors when deserializing empty lists as GPS locations

### DIFF
--- a/stravalib/attributes.py
+++ b/stravalib/attributes.py
@@ -181,7 +181,7 @@ class LocationAttribute(Attribute):
         """
         """
         if not isinstance(v, LatLon):
-            v = LatLon(lat=v[0], lon=v[1])
+            v = LatLon(lat=v[0], lon=v[1]) if v else None
         return v
 
 

--- a/stravalib/tests/unit/test_attributes.py
+++ b/stravalib/tests/unit/test_attributes.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 
 import six
 
-from stravalib.attributes import EntityAttribute, SUMMARY, DETAILED, ChoicesAttribute
+from stravalib.attributes import EntityAttribute, SUMMARY, DETAILED, ChoicesAttribute, LocationAttribute, LatLon
 from stravalib.model import Athlete, SubscriptionCallback
 from stravalib.tests import TestBase
 
@@ -44,6 +44,16 @@ class EntityAttributeTest(TestBase):
         print(dir(scb))
         self.assertEqual(d['hub.mode'], scb.hub_mode)
         self.assertEqual(d['hub.verify_token'], scb.hub_verify_token)
+
+
+class LocationAttributeTest(TestBase):
+    def test_with_location(self):
+        location = LocationAttribute((SUMMARY, DETAILED))
+        self.assertEqual(LatLon(1., 2.), location.unmarshal([1., 2.]))
+
+    def test_without_location(self):
+        location = LocationAttribute((SUMMARY, DETAILED))
+        self.assertIsNone(location.unmarshal([]))
 
 
 class ChoicesAttributeTest(TestBase):


### PR DESCRIPTION
Fixes #215. Since 2021-08-11, the Strava API returns an empty list for e.g. the `start_latlng` attribute.
This fix prevents `IndexError`s when deserializing these attributes.