### PR TITLE
fix get_athlete w new attrs for shoes given strava updates to API

### DIFF
--- a/stravalib/model.py
+++ b/stravalib/model.py
@@ -241,8 +241,11 @@ class Bike(Gear):
 
 class Shoe(Gear):
     """
-    Represent's an athlete's pair of shoes.
+    Represents an athlete's pair of shoes.
     """
+    nickname = Attribute(six.text_type, (DETAILED,))  #: Nickname for the shoe.
+    converted_distance = Attribute(float, (SUMMARY, DETAILED), units=uh.meters) # Distance on the shoe (meters)
+    retired = Attribute(bool, (SUMMARY, DETAILED))
 
 
 class ActivityTotals(BaseEntity):


### PR DESCRIPTION
This closes #220 
It looks like strava has made some changes to their API. this fixes a bug where a bunch of warnings are thrown given missing attributes for shoes. I have tested this locally but did not look closely at the test suite to ensure tests also work locally. @hozn if you need any changes to this please let me know. But please do know i didn't touch the test suite yet as i still need to set that up and dig into how you have tests setup locally. 

Thank you @yihong0618 for the direction regarding what the issue was! 