### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/stravalib/tests/functional/test_client.py
+++ b/stravalib/tests/functional/test_client.py
@@ -23,20 +23,20 @@ class ClientTest(FunctionalTestBase):
     def test_get_activity(self):
         """ Test basic activity fetching. """
         activity = self.client.get_activity(96089609)
-        self.assertEquals('El Dorado County, CA, USA', activity.location_city)
+        self.assertEqual('El Dorado County, CA, USA', activity.location_city)
 
         self.assertIsInstance(activity.start_latlng, attributes.LatLon)
-        self.assertAlmostEquals(-120.4357631, activity.start_latlng.lon, places=2)
-        self.assertAlmostEquals(38.74263759999999, activity.start_latlng.lat, places=2)
+        self.assertAlmostEqual(-120.4357631, activity.start_latlng.lon, places=2)
+        self.assertAlmostEqual(38.74263759999999, activity.start_latlng.lat, places=2)
 
         self.assertIsInstance(activity.map, model.Map)
 
         self.assertIsInstance(activity.athlete, model.Athlete)
-        self.assertEquals(1513, activity.athlete.id)
+        self.assertEqual(1513, activity.athlete.id)
 
         #self.assertAlmostEqual(first, second, places, msg, delta)
         # Ensure that iw as read in with correct units
-        self.assertEquals(22.5308, float(uh.kilometers(activity.distance)))
+        self.assertEqual(22.5308, float(uh.kilometers(activity.distance)))
 
     def test_get_activity_and_segments(self):
         """ Test include_all_efforts parameter on activity fetching. """
@@ -53,16 +53,16 @@ class ClientTest(FunctionalTestBase):
     def test_get_route(self):
         route = self.client.get_route(3445913)
 
-        self.assertEquals('Baveno - Mottarone', route.name)
-        self.assertAlmostEquals(1265.20, float(uh.meters(route.elevation_gain)), 2)
+        self.assertEqual('Baveno - Mottarone', route.name)
+        self.assertAlmostEqual(1265.20, float(uh.meters(route.elevation_gain)), 2)
 
     def test_get_activity_laps(self):
         activity = self.client.get_activity(165094211)
         laps = list(self.client.get_activity_laps(165094211))
-        self.assertEquals(5, len(laps))
+        self.assertEqual(5, len(laps))
         # This obviously is far from comprehensive, just a sanity check
-        self.assertEquals(u'Lap 1', laps[0].name)
-        self.assertEquals(178.0, laps[0].max_heartrate)
+        self.assertEqual(u'Lap 1', laps[0].name)
+        self.assertEqual(178.0, laps[0].max_heartrate)
 
 
     def test_get_activity_zones(self):
@@ -71,13 +71,13 @@ class ClientTest(FunctionalTestBase):
         """
         zones = self.client.get_activity_zones(99895560)
         print(zones)
-        self.assertEquals(1, len(zones))
+        self.assertEqual(1, len(zones))
         self.assertIsInstance(zones[0], model.PaceActivityZone)
 
         # Indirectly
         activity = self.client.get_activity(99895560)
-        self.assertEquals(len(zones), len(activity.zones))
-        self.assertEquals(zones[0].score, activity.zones[0].score)
+        self.assertEqual(len(zones), len(activity.zones))
+        self.assertEqual(zones[0].score, activity.zones[0].score)
 
     def test_activity_comments(self):
         """
@@ -86,8 +86,8 @@ class ClientTest(FunctionalTestBase):
         activity = self.client.get_activity(2290897)
         self.assertTrue(activity.comment_count > 0)
         comments= list(activity.comments)
-        self.assertEquals(3, len(comments))
-        self.assertEquals("I love Gordo's. I've been eating there for 20 years!", comments[0].text)
+        self.assertEqual(3, len(comments))
+        self.assertEqual("I love Gordo's. I've been eating there for 20 years!", comments[0].text)
 
     def test_activity_photos(self):
         """
@@ -191,27 +191,27 @@ class ClientTest(FunctionalTestBase):
 
     def test_get_athlete_clubs(self):
         clubs = self.client.get_athlete_clubs()
-        self.assertEquals(3, len(clubs))
-        self.assertEquals('Team Roaring Mouse', clubs[0].name)
-        self.assertEquals('Team Strava Cycling', clubs[1].name)
-        self.assertEquals('Team Strava Cyclocross', clubs[2].name)
+        self.assertEqual(3, len(clubs))
+        self.assertEqual('Team Roaring Mouse', clubs[0].name)
+        self.assertEqual('Team Strava Cycling', clubs[1].name)
+        self.assertEqual('Team Strava Cyclocross', clubs[2].name)
 
         clubs_indirect = self.client.get_athlete().clubs
-        self.assertEquals(3, len(clubs_indirect))
-        self.assertEquals(clubs[0].name, clubs_indirect[0].name)
-        self.assertEquals(clubs[1].name, clubs_indirect[1].name)
-        self.assertEquals(clubs[2].name, clubs_indirect[2].name)
+        self.assertEqual(3, len(clubs_indirect))
+        self.assertEqual(clubs[0].name, clubs_indirect[0].name)
+        self.assertEqual(clubs[1].name, clubs_indirect[1].name)
+        self.assertEqual(clubs[2].name, clubs_indirect[2].name)
 
     def test_get_gear(self):
         g = self.client.get_gear("g69911")
         self.assertTrue(float(g.distance) >= 3264.67)
-        self.assertEquals('Salomon XT Wings 2', g.name)
-        self.assertEquals('Salomon', g.brand_name)
+        self.assertEqual('Salomon XT Wings 2', g.name)
+        self.assertEqual('Salomon', g.brand_name)
         self.assertTrue(g.primary)
-        self.assertEquals(model.DETAILED, g.resource_state)
-        self.assertEquals('g69911', g.id)
-        self.assertEquals('XT Wings 2', g.model_name)
-        self.assertEquals('', g.description)
+        self.assertEqual(model.DETAILED, g.resource_state)
+        self.assertEqual('g69911', g.id)
+        self.assertEqual('XT Wings 2', g.model_name)
+        self.assertEqual('', g.description)
 
     def test_get_segment_leaderboard(self):
         lb = self.client.get_segment_leaderboard(229781)
@@ -220,20 +220,20 @@ class ClientTest(FunctionalTestBase):
         for i,e in enumerate(lb):
             print('{0}: {1}'.format(i, e))
 
-        self.assertEquals(10, len(lb.entries)) # 10 top results
+        self.assertEqual(10, len(lb.entries)) # 10 top results
         self.assertIsInstance(lb.entries[0], model.SegmentLeaderboardEntry)
-        self.assertEquals(1, lb.entries[0].rank)
+        self.assertEqual(1, lb.entries[0].rank)
         self.assertTrue(lb.effort_count > 8000) # At time of writing 8206
 
         # Check the relationships
         athlete = lb[0].athlete
         print(athlete)
-        self.assertEquals(lb[0].athlete_name, "{0} {1}".format(athlete.firstname, athlete.lastname))
+        self.assertEqual(lb[0].athlete_name, "{0} {1}".format(athlete.firstname, athlete.lastname))
 
         effort = lb[0].effort
         print(effort)
         self.assertIsInstance(effort, model.SegmentEffort)
-        self.assertEquals('Hawk Hill', effort.name)
+        self.assertEqual('Hawk Hill', effort.name)
 
         activity = lb[0].activity
         self.assertIsInstance(activity, model.Activity)
@@ -243,12 +243,12 @@ class ClientTest(FunctionalTestBase):
         segment = self.client.get_segment(229781)
         self.assertIsInstance(segment, model.Segment)
         print(segment)
-        self.assertEquals('Hawk Hill', segment.name)
+        self.assertEqual('Hawk Hill', segment.name)
         self.assertAlmostEqual(2.68, float(uh.kilometers(segment.distance)), places=2)
 
         # Fetch leaderboard
         lb = segment.leaderboard
-        self.assertEquals(10, len(lb)) # 10 top results, 5 bottom results
+        self.assertEqual(10, len(lb)) # 10 top results, 5 bottom results
 
     def test_get_segment_efforts(self):
         # test with string
@@ -294,11 +294,11 @@ class ClientTest(FunctionalTestBase):
         results = self.client.explore_segments(bounds)
 
         # This might be brittle
-        self.assertEquals('Hawk Hill', results[0].name)
+        self.assertEqual('Hawk Hill', results[0].name)
 
         # Fetch full segment
         segment = results[0].segment
-        self.assertEquals(results[0].name, segment.name)
+        self.assertEqual(results[0].name, segment.name)
 
         # For some reason these don't follow the simple math rules one might expect (so we round to int)
         self.assertAlmostEqual(results[0].elev_difference, segment.elevation_high - segment.elevation_low, places=0)

--- a/stravalib/tests/functional/test_client_utils.py
+++ b/stravalib/tests/functional/test_client_utils.py
@@ -11,7 +11,7 @@ class ClientUtilsTest(TestBase):
 
     def test_utc_datetime_to_epoch_utc_datetime_given_correct_epoch_returned(self):
         dt = pytz.utc.localize(datetime.datetime(2014, 1, 1, 0, 0, 0))
-        self.assertEquals(1388534400, self.client._utc_datetime_to_epoch(dt))
+        self.assertEqual(1388534400, self.client._utc_datetime_to_epoch(dt))
 
 
 class ClientAuthorizationUrlTest(TestBase):

--- a/stravalib/tests/functional/test_client_write.py
+++ b/stravalib/tests/functional/test_client_write.py
@@ -21,10 +21,10 @@ class ClientWriteTest(FunctionalTestBase):
         print(a)
         
         self.assertIsInstance(a, model.Activity)
-        self.assertEquals("test_create_activity#simple", a.name)
-        self.assertEquals(now, a.start_date_local)
-        self.assertEquals(round(float(uh.miles(15.2)), 2), round(float(uh.miles(a.distance)), 2))
-        self.assertEquals(timedelta(hours=3, minutes=4, seconds=5), a.elapsed_time)
+        self.assertEqual("test_create_activity#simple", a.name)
+        self.assertEqual(now, a.start_date_local)
+        self.assertEqual(round(float(uh.miles(15.2)), 2), round(float(uh.miles(a.distance)), 2))
+        self.assertEqual(timedelta(hours=3, minutes=4, seconds=5), a.elapsed_time)
     
     
     def test_update_activity(self):
@@ -39,10 +39,10 @@ class ClientWriteTest(FunctionalTestBase):
                                         distance=uh.miles(15.2))
         
         self.assertIsInstance(a, model.Activity)
-        self.assertEquals("test_update_activity#create", a.name)
+        self.assertEqual("test_update_activity#create", a.name)
         
         update1 = self.client.update_activity(a.id, name="test_update_activivty#update")
-        self.assertEquals("test_update_activivty#update", update1.name)
+        self.assertEqual("test_update_activivty#update", update1.name)
         self.assertFalse(update1.private)
         self.assertFalse(update1.trainer)
         self.assertFalse(update1.commute)
@@ -69,7 +69,7 @@ class ClientWriteTest(FunctionalTestBase):
             a = uploader.wait()
             self.assertTrue(uploader.is_complete)
             self.assertIsInstance(a, model.Activity)
-            self.assertEquals("02/21/2009 Leiden, ZH, The Netherlands", a.name)
+            self.assertEqual("02/21/2009 Leiden, ZH, The Netherlands", a.name)
             
             # And we'll get an error if we try the same file again
             with self.assertRaises(exc.ActivityUploadFailed):

--- a/stravalib/tests/functional/test_result_iterator.py
+++ b/stravalib/tests/functional/test_result_iterator.py
@@ -17,7 +17,7 @@ class ResultIteratorTest(FunctionalTestBase):
         result_fetcher = functools.partial(self.protocol.get, '/athlete/activities')
         results = BatchedResultsIterator(entity=model.Activity, result_fetcher=result_fetcher, limit=10, per_page=2)
         results = list(results)
-        self.assertEquals(10, len(results))
+        self.assertEqual(10, len(results))
     
     def test_multiple_iterator_calls(self):
         """ Test multiple calls of the iterator. """
@@ -28,8 +28,8 @@ class ResultIteratorTest(FunctionalTestBase):
         results1 = list(results)
         results2 = list(results)
         
-        self.assertEquals(10, len(results1))
-        self.assertEquals(len(results1), len(results2))
+        self.assertEqual(10, len(results1))
+        self.assertEqual(len(results1), len(results2))
     
     
     def test_limit_iterator(self):
@@ -39,7 +39,7 @@ class ResultIteratorTest(FunctionalTestBase):
         results = BatchedResultsIterator(entity=model.Activity, result_fetcher=result_fetcher, limit=10, per_page=2)
         results.limit = 10
         results = list(results)
-        self.assertEquals(10, len(results))
+        self.assertEqual(10, len(results))
             
         
         # TODO: use a mock here to figure out how many calls are happening under the hood.
@@ -52,5 +52,5 @@ class ResultIteratorTest(FunctionalTestBase):
         
         ri = BatchedResultsIterator(entity=model.Shoe, result_fetcher=pretend_fetcher)
         results = list(ri)
-        self.assertEquals(0, len(results))
+        self.assertEqual(0, len(results))
     

--- a/stravalib/tests/unit/test_model.py
+++ b/stravalib/tests/unit/test_model.py
@@ -19,16 +19,16 @@ class ModelTest(TestBase):
              }
         a.from_dict(d)
 
-        self.assertEquals(3, len(a.clubs))
-        self.assertEquals('Team Roaring Mouse', a.clubs[0].name)
+        self.assertEqual(3, len(a.clubs))
+        self.assertEqual('Team Roaring Mouse', a.clubs[0].name)
 
     def test_speed_units(self):
         a = model.Activity()
 
         a.max_speed = 1000  # m/s
         a.average_speed = 1000  # m/s
-        self.assertEquals(3600.0, float(uh.kph(a.max_speed)))
-        self.assertEquals(3600.0, float(uh.kph(a.average_speed)))
+        self.assertEqual(3600.0, float(uh.kph(a.max_speed)))
+        self.assertEqual(3600.0, float(uh.kph(a.average_speed)))
 
         a.max_speed = uh.mph(1.0)
         # print repr(a.max_speed)
@@ -47,7 +47,7 @@ class ModelTest(TestBase):
         # Gear
         g = model.Gear()
         g.distance = 1000
-        self.assertEquals(1.0, float(uh.kilometers(g.distance)))
+        self.assertEqual(1.0, float(uh.kilometers(g.distance)))
 
         # Metric Split
         split = model.Split()
@@ -55,8 +55,8 @@ class ModelTest(TestBase):
         split.elevation_difference = 1000  # meters
         self.assertIsInstance(split.distance, Quantity)
         self.assertIsInstance(split.elevation_difference, Quantity)
-        self.assertEquals(1.0, float(uh.kilometers(split.distance)))
-        self.assertEquals(1.0, float(uh.kilometers(split.elevation_difference)))
+        self.assertEqual(1.0, float(uh.kilometers(split.distance)))
+        self.assertEqual(1.0, float(uh.kilometers(split.elevation_difference)))
         split = None
 
         # Segment
@@ -67,9 +67,9 @@ class ModelTest(TestBase):
         self.assertIsInstance(s.distance, Quantity)
         self.assertIsInstance(s.elevation_high, Quantity)
         self.assertIsInstance(s.elevation_low, Quantity)
-        self.assertEquals(1.0, float(uh.kilometers(s.distance)))
-        self.assertEquals(2.0, float(uh.kilometers(s.elevation_high)))
-        self.assertEquals(1.0, float(uh.kilometers(s.elevation_low)))
+        self.assertEqual(1.0, float(uh.kilometers(s.distance)))
+        self.assertEqual(2.0, float(uh.kilometers(s.elevation_high)))
+        self.assertEqual(1.0, float(uh.kilometers(s.elevation_low)))
 
         # Activity
         a = model.Activity()
@@ -77,8 +77,8 @@ class ModelTest(TestBase):
         a.total_elevation_gain = 1000  # m
         self.assertIsInstance(a.distance, Quantity)
         self.assertIsInstance(a.total_elevation_gain, Quantity)
-        self.assertEquals(1.0, float(uh.kilometers(a.distance)))
-        self.assertEquals(1.0, float(uh.kilometers(a.total_elevation_gain)))
+        self.assertEqual(1.0, float(uh.kilometers(a.distance)))
+        self.assertEqual(1.0, float(uh.kilometers(a.total_elevation_gain)))
 
     def test_weight_units(self):
         """


### PR DESCRIPTION
Deprecated unittest aliases were removed in Python 3.11 . The recommended aliases are present in both Python 2.7 and Python 3. So the PR is backwards compatible.

assertEquals -> assertEqual
assertAlmostEquals -> assertAlmostEqual

Ref : https://github.com/python/cpython/pull/28268