### PR TITLE
FIX: Remove false warning about response headers on authentication calls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Fix: Remove false warning about response headers on authentication calls (@BPR02, #667)
 - Fix: Improve response header handling (@BPR02, #664)
 - Fix: Adds necessary permissions for update-model job (@jsamoocha, #654)
 - Chore(ci): Update and fix dependabot (@lwasser, #657)

--- a/docs/get-started/how-to-get-strava-data-python.md
+++ b/docs/get-started/how-to-get-strava-data-python.md
@@ -284,11 +284,9 @@ Now you're ready to use this code to authenticate!
 ```python
 # Open the url that you created above in a web browser
 webbrowser.open(url)
-print(
-    """You will see a URL that looks like this:
+print("""You will see a URL that looks like this:
     http://127.0.0.1:5000/authorization?state=&code=12323423423423423423423550&scope=read,activity:read_all,profile:read_all,read_all
-    Copy the values between code= and & in the URL that you see in the browser."""
-)
+    Copy the values between code= and & in the URL that you see in the browser.""")
 # Using input allows you to copy the code into your Python console (or Jupyter Notebook)
 code = input("Please enter the code that you received: ")
 

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -219,7 +219,7 @@ class ApiV3(metaclass=abc.ABCMeta):
         raw = requester(url, params=params)  # type: ignore[operator]
         # Rate limits are taken from HTTP response headers
         # https://developers.strava.com/docs/rate-limits/
-        if "/oauth/token" not in url:
+        if "/oauth/" not in url:
             self.rate_limiter(raw.headers, method)
 
         if check_for_errors:

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -219,7 +219,8 @@ class ApiV3(metaclass=abc.ABCMeta):
         raw = requester(url, params=params)  # type: ignore[operator]
         # Rate limits are taken from HTTP response headers
         # https://developers.strava.com/docs/rate-limits/
-        self.rate_limiter(raw.headers, method)
+        if "/oauth/token" not in url:
+            self.rate_limiter(raw.headers, method)
 
         if check_for_errors:
             self._handle_protocol_error(raw)


### PR DESCRIPTION
closes #608 

_The text above will ensure the issue will be closed when this PR is merged_

<!--- * If this pr does not address an open issue  in the repository, please be sure
to explain what this pull request fixes or does. We prefer to discuss changes in issues first, to just ensure we are all on the same page about the change being proposed.

* If this is a technical code change, please be sure that you have [read our contributing guide.](https://stravalib.readthedocs.io/en/latest/contributing/how-to-contribute.html)
-->

## Description

<!--- Please describe changes made in this pull request in detail -->
This PR updates the `_request` method in ApiV3 so that the rate limiter (`self.rate_limiter`) does not run for authentication calls. This is done by only running the rate limiter if `"/oauth/token"` is not in the url.

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [x] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

_If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!_

<!---
If you are a stravalib maintainer submitting a PR in preparation for a new release
you can use the pull request release template:

[https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md](https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md). Be sure to modify
the text "branch-name-here" in the above url to apply the release template.
-->
