### PR TITLE
Add Typer CLI with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,55 @@ a Strava app.](https://stravalib.readthedocs.io/en/latest/get-started/authentica
 2. [Athlete data using stravalib](https://stravalib.readthedocs.io/en/latest/get-started/athletes.html)
 3. [Unit conversion and stravalib](https://stravalib.readthedocs.io/en/latest/get-started/activities.html#stravalib-offers-unit-conversion-helpers)
 
+## Command-line interface
+
+stravalib now ships with a Typer-powered CLI that mirrors the `Client` API. Once
+installed (either from PyPI or locally with `uv pip install -e .`), explore the
+command tree via:
+
+```bash
+$ uv run stravalib --help
+```
+
+The CLI keeps a few root-level shortcuts (`whoami`, `activities-recent`, `activity`,
+`activity-streams`) and organises the rest into subcommands:
+
+- `auth` – authorization URLs, token exchanges/refreshes, and deauthorize.
+- `athlete` – profile, zones, stats, KOMs, and club memberships.
+- `activities` – list/get, create/update, uploads, comments, zones, photos,
+  laps, streams, and kudos.
+- `clubs` – lookups, members, activities, admins, join/leave actions.
+- `segments` – lookups, starred segments, effort queries, explore, streams.
+- `routes` – saved routes and their streams.
+- `gear` – fetch gear metadata by ID.
+- `subscriptions` – webhook subscription lifecycle and callback helpers.
+
+Every command honours the usual environment variables (`STRAVA_ACCESS_TOKEN`,
+`STRAVA_REFRESH_TOKEN`, `STRAVA_TOKEN_EXPIRES_AT`, `STRAVA_CLIENT_ID`,
+`STRAVA_CLIENT_SECRET`). You can override them per-invocation with the shared
+global options (`--access-token`, `--refresh-token`, etc.).
+
+Examples:
+
+```bash
+# Fetch the authenticated athlete profile
+$ uv run stravalib athlete profile
+
+# List recent activities (alias and grouped command both work)
+$ uv run stravalib activities --limit 5
+$ uv run stravalib activities list --limit 5
+
+# Explore segments within a bounding box
+$ uv run stravalib segments explore \
+    --south-lat 29.60 --west-lng -95.80 --north-lat 29.90 --east-lng -95.10
+
+# Upload a FIT file and poll until processing completes
+$ uv run stravalib activities upload ./ride.fit --data-type fit --poll
+```
+
+See the "CLI" guide under the documentation `get-started` section for more
+workflow-oriented examples.
+
 We welcome contributions to our tutorials and get-started documentation if you are a stravalib user and want to contribute!
 
 

--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -1,0 +1,96 @@
+# Use the stravalib CLI
+
+The `stravalib` package now ships with a comprehensive Typer-based command line
+interface. It mirrors the full `Client` surface area, making it easy to perform
+ad-hoc queries or build shell pipelines without writing Python scripts.
+
+## Installation and setup
+
+Install the package (or your local clone) and make sure the standard Strava
+environment variables are exported:
+
+```bash
+uv pip install -e .
+
+export STRAVA_CLIENT_ID=12345
+export STRAVA_CLIENT_SECRET=...    # keep this secret!
+export STRAVA_ACCESS_TOKEN=...
+export STRAVA_REFRESH_TOKEN=...
+export STRAVA_TOKEN_EXPIRES_AT=1700000000
+```
+
+Every command also accepts runtime overrides: `--access-token`,
+`--refresh-token`, `--token-expires`, and `--rate-limit/--no-rate-limit`.
+
+List the full command tree:
+
+```bash
+uv run stravalib --help
+```
+
+The top-level shortcuts (`whoami`, `activities-recent`, `activity`, `activity-streams`)
+remain for muscle memory. All other functionality is grouped under
+subcommands:
+
+| Group | Highlights |
+|-------|------------|
+| `auth` | Generate authorization URLs, exchange/refresh tokens, deauthorize |
+| `athlete` | Profile, zones, stats, KOMs, club memberships |
+| `activities` | List/get, create/update, uploads (with optional polling), comments, zones, photos, laps, streams, kudos |
+| `clubs` | Fetch club details, members, activities, admins, join/leave |
+| `segments` | Segment lookup, starred segments, effort searches, explore, streams |
+| `routes` | Athlete routes and route streams |
+| `gear` | Fetch bike/shoe metadata |
+| `subscriptions` | Manage webhook subscriptions and validate callbacks |
+
+## Usage examples
+
+### Inspect the current athlete
+
+```bash
+uv run stravalib athlete profile
+```
+
+### Review recent activities
+
+```bash
+uv run stravalib activities list --limit 10 --after 2025-01-01
+```
+
+### Upload a FIT file and wait for processing
+
+```bash
+uv run stravalib activities upload ./ride.fit --data-type fit --poll
+```
+
+### Explore segments in a bounding box
+
+```bash
+uv run stravalib segments explore \
+    --south-lat 29.60 --west-lng -95.80 \
+    --north-lat 29.90 --east-lng -95.10
+```
+
+### Manage webhook subscriptions
+
+```bash
+uv run stravalib subscriptions create \
+    --client-id $STRAVA_CLIENT_ID \
+    --client-secret $STRAVA_CLIENT_SECRET \
+    --callback-url https://example.com/strava/webhook
+
+uv run stravalib subscriptions list \
+    --client-id $STRAVA_CLIENT_ID \
+    --client-secret $STRAVA_CLIENT_SECRET
+```
+
+### Quick reference
+
+Use `--help` on any subcommand to discover parameter details, for example:
+
+```bash
+uv run stravalib segments efforts --help
+```
+
+All results are emitted as JSON. Pass `--output-file path.json` to write the
+response to disk instead of stdout, and adjust formatting with `--indent`.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -9,6 +9,7 @@ Overview <overview>
 Authentication <authenticate-with-strava>
 Activities <activities>
 Athletes <athletes>
+CLI <cli>
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,22 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 
-dependencies = ["pint", "pytz", "arrow", "requests", "pydantic>=2.0"]
+dependencies = [
+    "pint",
+    "pytz",
+    "arrow",
+    "requests",
+    "pydantic>=2.0",
+    "typer",
+]
 
 [project.urls]
 documentation = "https://stravalib.readthedocs.io"
 repository = "https://github.com/stravalib/stravalib"
 changelog = "https://github.com/stravalib/stravalib/blob/main/changelog.md"
+
+[project.scripts]
+stravalib = "stravalib.cli:main_entry"
 
 
 [project.optional-dependencies]

--- a/src/stravalib/cli.py
+++ b/src/stravalib/cli.py
@@ -1,0 +1,1200 @@
+"""Typer-based CLI for the stravalib client."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import wraps
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import click
+import typer
+from pydantic import BaseModel
+from requests import exceptions as requests_exceptions
+
+from stravalib import exc, model
+from stravalib.client import ActivityUploader, BatchedResultsIterator, Client
+from stravalib.util import limiter
+
+app = typer.Typer(help="Interact with Strava data via stravalib.")
+auth_app = typer.Typer(help="OAuth and token utilities.")
+athlete_app = typer.Typer(help="Athlete profile and statistics.")
+activities_app = typer.Typer(help="Activity management and queries.")
+clubs_app = typer.Typer(help="Club discovery and membership tools.")
+segments_app = typer.Typer(help="Segment lookups and analytics.")
+routes_app = typer.Typer(help="Route listings and stream data.")
+gear_app = typer.Typer(help="Gear information.")
+subscriptions_app = typer.Typer(help="Webhook subscription helpers.")
+
+app.add_typer(auth_app, name="auth")
+app.add_typer(athlete_app, name="athlete")
+app.add_typer(activities_app, name="activities")
+app.add_typer(clubs_app, name="clubs")
+app.add_typer(segments_app, name="segments")
+app.add_typer(routes_app, name="routes")
+app.add_typer(gear_app, name="gear")
+app.add_typer(subscriptions_app, name="subscriptions")
+
+
+@dataclass
+class CLIState:
+    """Shared state for CLI commands."""
+
+    client: Client | None = None
+    indent: int = 2
+    output_path: Path | None = None
+
+
+def _get_state(ctx: typer.Context) -> CLIState:
+    obj = ctx.obj
+    if obj is None:
+        obj = CLIState()
+        ctx.obj = obj
+    assert isinstance(obj, CLIState)
+    return obj
+
+
+def _current_context() -> typer.Context:
+    return click.get_current_context()  # type: ignore[return-value]
+
+
+def _build_client(
+    *,
+    access_token: str | None,
+    refresh_token: str | None,
+    token_expires: int | None,
+    rate_limit: bool,
+) -> Client:
+    client = Client(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_expires=token_expires,
+        rate_limit_requests=rate_limit,
+    )
+    if refresh_token:
+        client.refresh_token = refresh_token
+    return client
+
+
+def _noop_rate_limiter(_headers: dict[str, str], _method: str) -> None:
+    return None
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _prepare_result(data: Any) -> Any:
+    if isinstance(data, BatchedResultsIterator):
+        return [_prepare_result(item) for item in list(data)]
+    if isinstance(data, BaseModel):
+        return data.model_dump(mode="json")
+    if isinstance(data, ActivityUploader):
+        return {
+            "upload_id": data.upload_id,
+            "external_id": data.external_id,
+            "activity_id": data.activity_id,
+            "status": data.status,
+            "error": data.error,
+            "photo_metadata": data.photo_metadata,
+        }
+    if isinstance(data, dict):
+        return {key: _prepare_result(value) for key, value in data.items()}
+    if isinstance(data, Sequence) and not isinstance(
+        data, (str, bytes, bytearray)
+    ):
+        return [_prepare_result(item) for item in data]
+    if isinstance(data, Iterable) and not isinstance(
+        data, (str, bytes, bytearray)
+    ):
+        return [_prepare_result(item) for item in list(data)]
+    return data
+
+
+def _emit_result(ctx: typer.Context, data: Any) -> None:
+    state = _get_state(ctx)
+    payload = _prepare_result(data)
+    text = json.dumps(payload, indent=state.indent, default=_json_default)
+    if state.output_path:
+        state.output_path.parent.mkdir(parents=True, exist_ok=True)
+        state.output_path.write_text(f"{text}\n", encoding="utf-8")
+        typer.secho(
+            f"Saved response to {state.output_path}", err=True, fg="green"
+        )
+    else:
+        typer.echo(text)
+
+
+def _handle_api_errors(func):
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        try:
+            return func(*args, **kwargs)
+        except (
+            exc.Fault,
+            exc.ObjectNotFound,
+            exc.AccessUnauthorized,
+        ) as error:
+            typer.secho(f"Strava API error: {error}", err=True, fg="red")
+            raise typer.Exit(code=1) from error
+        except requests_exceptions.RequestException as error:
+            typer.secho(f"HTTP error: {error}", err=True, fg="red")
+            raise typer.Exit(code=1) from error
+
+    return wrapper
+
+
+def _get_client() -> Client:
+    ctx = _current_context()
+    state = _get_state(ctx)
+    if state.client is None:
+        typer.secho("Strava client is not initialised.", err=True, fg="red")
+        raise typer.Exit(code=1)
+    return state.client
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    access_token: str | None = typer.Option(
+        None,
+        "--access-token",
+        envvar="STRAVA_ACCESS_TOKEN",
+        help="Short-lived Strava access token.",
+    ),
+    refresh_token: str | None = typer.Option(
+        None,
+        "--refresh-token",
+        envvar="STRAVA_REFRESH_TOKEN",
+        help="Refresh token used to obtain new access tokens.",
+    ),
+    token_expires: int | None = typer.Option(
+        None,
+        "--token-expires",
+        envvar="STRAVA_TOKEN_EXPIRES_AT",
+        help="Epoch timestamp (seconds) when current access token expires.",
+    ),
+    rate_limit: bool = typer.Option(
+        True,
+        "--rate-limit/--no-rate-limit",
+        help="Enable client-side rate limiting.",
+    ),
+    indent: int = typer.Option(
+        2,
+        "--indent",
+        min=0,
+        max=8,
+        help="Indent level for JSON output.",
+    ),
+    output_file: Path | None = typer.Option(
+        None,
+        "--output-file",
+        "-o",
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        readable=False,
+        resolve_path=True,
+        help="Write JSON response to the given file path.",
+    ),
+) -> None:
+    state = _get_state(ctx)
+    state.indent = indent
+    state.output_path = output_file
+
+    if state.client is None:
+        state.client = _build_client(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            token_expires=token_expires,
+            rate_limit=rate_limit,
+        )
+    else:
+        if access_token:
+            state.client.access_token = access_token
+        if refresh_token:
+            state.client.refresh_token = refresh_token
+        if token_expires is not None:
+            state.client.token_expires = token_expires
+        if rate_limit:
+            state.client.protocol.rate_limiter = limiter.DefaultRateLimiter()
+        else:
+            state.client.protocol.rate_limiter = _noop_rate_limiter
+
+
+# ---------------------------------------------------------------------------
+# Authentication utilities
+# ---------------------------------------------------------------------------
+
+
+@auth_app.command("authorization-url")
+@_handle_api_errors
+def auth_authorization_url(
+    client_id: int = typer.Option(..., help="Strava application client id."),
+    redirect_uri: str = typer.Option(
+        ..., help="Redirect URI configured in Strava."
+    ),
+    approval_prompt: str = typer.Option(
+        "auto", help="Approval prompt behaviour: auto or force."
+    ),
+    scope: list[str] | None = typer.Option(
+        None,
+        "--scope",
+        "-s",
+        help="Scopes to request (repeat option for multiple).",
+    ),
+    state_token: str | None = typer.Option(
+        None, "--state", help="Opaque state value."
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    scopes = scope if scope else None
+    url = client.authorization_url(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        approval_prompt=approval_prompt,  # type: ignore[arg-type]
+        scope=scopes,
+        state=state_token,
+    )
+    _emit_result(ctx, {"authorization_url": url})
+
+
+@auth_app.command("exchange-token")
+@_handle_api_errors
+def auth_exchange_token(
+    client_id: int = typer.Option(..., help="Strava application client id."),
+    client_secret: str = typer.Option(
+        ..., help="Strava application client secret."
+    ),
+    code: str = typer.Option(
+        ..., help="Authorization code returned from Strava."
+    ),
+    return_athlete: bool = typer.Option(
+        False,
+        "--return-athlete/--no-return-athlete",
+        help="Include the athlete payload in the response.",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    result = client.exchange_code_for_token(
+        client_id=client_id,
+        client_secret=client_secret,
+        code=code,
+        return_athlete=return_athlete,
+    )
+    if return_athlete:
+        access_info, athlete = result
+        payload = {
+            "access_info": access_info,
+            "athlete": _prepare_result(athlete) if athlete else None,
+        }
+    else:
+        payload = result
+    _emit_result(ctx, payload)
+
+
+@auth_app.command("refresh-token")
+@_handle_api_errors
+def auth_refresh_token(
+    client_id: int = typer.Option(..., help="Strava application client id."),
+    client_secret: str = typer.Option(
+        ..., help="Strava application client secret."
+    ),
+    refresh_token: str = typer.Option(..., help="Existing refresh token."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    info = client.refresh_access_token(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+    )
+    _emit_result(ctx, info)
+
+
+@auth_app.command("deauthorize")
+@_handle_api_errors
+def auth_deauthorize() -> None:
+    ctx = _current_context()
+    client = _get_client()
+    client.deauthorize()
+    _emit_result(ctx, {"message": "Application deauthorized."})
+
+
+# ---------------------------------------------------------------------------
+# Athlete operations
+# ---------------------------------------------------------------------------
+
+
+@athlete_app.command("profile")
+@_handle_api_errors
+def athlete_profile() -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_athlete())
+
+
+@athlete_app.command("update")
+@_handle_api_errors
+def athlete_update(
+    city: str | None = typer.Option(None, help="City for the athlete."),
+    state_region: str | None = typer.Option(
+        None, "--state", help="State or region."
+    ),
+    country: str | None = typer.Option(None, help="Country."),
+    sex: str | None = typer.Option(None, help="Gender marker."),
+    weight: float | None = typer.Option(None, help="Weight in kilograms."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    athlete = client.update_athlete(
+        city=city,
+        state=state_region,
+        country=country,
+        sex=sex,
+        weight=weight,
+    )
+    _emit_result(ctx, athlete)
+
+
+@athlete_app.command("zones")
+@_handle_api_errors
+def athlete_zones() -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_athlete_zones())
+
+
+@athlete_app.command("stats")
+@_handle_api_errors
+def athlete_stats(
+    athlete_id: int | None = typer.Option(
+        None,
+        help="Optional athlete id (defaults to authenticated athlete).",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_athlete_stats(athlete_id=athlete_id))
+
+
+@athlete_app.command("koms")
+@_handle_api_errors
+def athlete_koms(
+    athlete_id: int | None = typer.Option(
+        None,
+        help="Athlete id (defaults to authenticated athlete).",
+    ),
+    limit: int | None = typer.Option(None, help="Maximum KOMs to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    target_id = athlete_id or client.get_athlete().id
+    koms = client.get_athlete_koms(target_id, limit=limit)
+    _emit_result(ctx, koms)
+
+
+@athlete_app.command("clubs")
+@_handle_api_errors
+def athlete_clubs(
+    limit: int | None = typer.Option(None, help="Maximum clubs to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_athlete_clubs(limit=limit))
+
+
+# ---------------------------------------------------------------------------
+# Activity operations
+# ---------------------------------------------------------------------------
+
+
+@activities_app.command("list")
+@_handle_api_errors
+def activities_list(
+    limit: int = typer.Option(
+        20, "--limit", min=1, help="Number of activities to fetch."
+    ),
+    before: datetime | None = typer.Option(
+        None,
+        "--before",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Only include activities that start before this timestamp (UTC).",
+    ),
+    after: datetime | None = typer.Option(
+        None,
+        "--after",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Only include activities that start after this timestamp (UTC).",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    activities = client.get_activities(before=before, after=after, limit=limit)
+    _emit_result(ctx, activities)
+
+
+@activities_app.command("get")
+@_handle_api_errors
+def activities_get(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    include_all_efforts: bool = typer.Option(
+        False,
+        "--include-all-efforts/--no-include-all-efforts",
+        help="Request all efforts for the activity (may be slower).",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.get_activity(
+            activity_id, include_all_efforts=include_all_efforts
+        ),
+    )
+
+
+@activities_app.command("create")
+@_handle_api_errors
+def activities_create(
+    name: str = typer.Option(..., help="Name of the activity."),
+    start_date_local: datetime = typer.Option(
+        ...,
+        "--start-date",
+        formats=["%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Local start datetime.",
+    ),
+    elapsed_time: int = typer.Option(..., help="Elapsed time in seconds."),
+    sport_type: str | None = typer.Option(
+        None, help="Sport type (preferred)."
+    ),
+    activity_type: str | None = typer.Option(
+        None, help="Legacy activity type (deprecated by Strava)."
+    ),
+    description: str | None = typer.Option(None, help="Activity description."),
+    distance: float | None = typer.Option(None, help="Distance in meters."),
+    trainer: bool | None = typer.Option(
+        None, help="Mark as trainer activity."
+    ),
+    commute: bool | None = typer.Option(None, help="Mark as commute."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    activity = client.create_activity(
+        name=name,
+        start_date_local=start_date_local,
+        elapsed_time=elapsed_time,
+        sport_type=sport_type,
+        activity_type=activity_type,
+        description=description,
+        distance=distance,
+        trainer=trainer,
+        commute=commute,
+    )
+    _emit_result(ctx, activity)
+
+
+@activities_app.command("update")
+@_handle_api_errors
+def activities_update(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    name: str | None = typer.Option(None, help="New name."),
+    sport_type: str | None = typer.Option(None, help="Sport type."),
+    activity_type: str | None = typer.Option(
+        None, help="Legacy activity type."
+    ),
+    description: str | None = typer.Option(None, help="Description."),
+    private: bool | None = typer.Option(None, help="Mark as private."),
+    commute: bool | None = typer.Option(None, help="Mark as commute."),
+    trainer: bool | None = typer.Option(None, help="Mark as trainer."),
+    gear_id: int | None = typer.Option(None, help="Gear identifier."),
+    device_name: str | None = typer.Option(None, help="Device name."),
+    hide_from_home: bool | None = typer.Option(None, help="Mute activity."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    activity = client.update_activity(
+        activity_id=activity_id,
+        name=name,
+        sport_type=sport_type,
+        activity_type=activity_type,
+        description=description,
+        private=private,
+        commute=commute,
+        trainer=trainer,
+        gear_id=gear_id,
+        device_name=device_name,
+        hide_from_home=hide_from_home,
+    )
+    _emit_result(ctx, activity)
+
+
+@activities_app.command("zones")
+@_handle_api_errors
+def activities_zones(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_activity_zones(activity_id))
+
+
+@activities_app.command("comments")
+@_handle_api_errors
+def activities_comments(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    markdown: bool = typer.Option(
+        False,
+        "--markdown/--no-markdown",
+        help="Return markdown content.",
+    ),
+    limit: int | None = typer.Option(None, help="Maximum comments to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.get_activity_comments(
+            activity_id, markdown=markdown, limit=limit
+        ),
+    )
+
+
+@activities_app.command("kudos")
+@_handle_api_errors
+def activities_kudos(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    limit: int | None = typer.Option(None, help="Maximum kudos to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_activity_kudos(activity_id, limit=limit))
+
+
+@activities_app.command("photos")
+@_handle_api_errors
+def activities_photos(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    size: int | None = typer.Option(None, help="Requested photo size."),
+    only_instagram: bool = typer.Option(
+        False,
+        "--only-instagram/--all-photos",
+        help="Limit to Instagram photos only.",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.get_activity_photos(
+            activity_id, size=size, only_instagram=only_instagram
+        ),
+    )
+
+
+@activities_app.command("laps")
+@_handle_api_errors
+def activities_laps(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_activity_laps(activity_id))
+
+
+@activities_app.command("streams")
+@_handle_api_errors
+def activities_streams(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    stream_types: list[str] | None = typer.Option(
+        None,
+        "--stream",
+        "-s",
+        help="Stream types to request (repeat option).",
+    ),
+    resolution: str | None = typer.Option(None, help="Stream resolution."),
+    series_type: str | None = typer.Option(None, help="Series type."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    streams = client.get_activity_streams(
+        activity_id,
+        types=stream_types or None,
+        resolution=resolution,
+        series_type=series_type,
+    )
+    _emit_result(ctx, streams)
+
+
+@activities_app.command("upload")
+@_handle_api_errors
+def activities_upload(
+    activity_file: Path = typer.Argument(
+        ..., help="Path to the activity file."
+    ),
+    data_type: str = typer.Option(
+        ..., help="File format (fit, tcx, gpx, etc.)."
+    ),
+    name: str | None = typer.Option(None, help="Optional name."),
+    description: str | None = typer.Option(None, help="Description."),
+    activity_type: str | None = typer.Option(
+        None, help="Legacy activity type."
+    ),
+    private: bool | None = typer.Option(None, help="Mark as private."),
+    external_id: str | None = typer.Option(None, help="External identifier."),
+    trainer: bool | None = typer.Option(None, help="Mark as trainer."),
+    commute: bool | None = typer.Option(None, help="Mark as commute."),
+    poll: bool = typer.Option(
+        False,
+        "--poll/--no-poll",
+        help="Wait for Strava to finish processing the upload.",
+    ),
+    timeout: float | None = typer.Option(
+        None, help="Timeout in seconds when polling."
+    ),
+    poll_interval: float = typer.Option(
+        1.0, help="Polling interval in seconds."
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    with activity_file.open("rb") as fh:
+        uploader = client.upload_activity(
+            fh,
+            data_type=data_type,
+            name=name,
+            description=description,
+            activity_type=activity_type,
+            private=private,
+            external_id=external_id,
+            trainer=trainer,
+            commute=commute,
+        )
+    if poll:
+        activity = uploader.wait(timeout=timeout, poll_interval=poll_interval)
+        _emit_result(ctx, {"upload": uploader, "activity": activity})
+    else:
+        _emit_result(ctx, uploader)
+
+
+# ---------------------------------------------------------------------------
+# Club operations
+# ---------------------------------------------------------------------------
+
+
+@clubs_app.command("get")
+@_handle_api_errors
+def clubs_get(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_club(club_id))
+
+
+@clubs_app.command("members")
+@_handle_api_errors
+def clubs_members(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+    limit: int | None = typer.Option(None, help="Maximum members to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_club_members(club_id, limit=limit))
+
+
+@clubs_app.command("activities")
+@_handle_api_errors
+def clubs_activities(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+    limit: int | None = typer.Option(
+        None, help="Maximum activities to return."
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_club_activities(club_id, limit=limit))
+
+
+@clubs_app.command("admins")
+@_handle_api_errors
+def clubs_admins(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+    limit: int | None = typer.Option(None, help="Maximum admins to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_club_admins(club_id, limit=limit))
+
+
+@clubs_app.command("join")
+@_handle_api_errors
+def clubs_join(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    client.join_club(club_id)
+    _emit_result(ctx, {"message": f"Joined club {club_id}."})
+
+
+@clubs_app.command("leave")
+@_handle_api_errors
+def clubs_leave(
+    club_id: int = typer.Argument(..., help="Club identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    client.leave_club(club_id)
+    _emit_result(ctx, {"message": f"Left club {club_id}."})
+
+
+# ---------------------------------------------------------------------------
+# Segment operations
+# ---------------------------------------------------------------------------
+
+
+@segments_app.command("get")
+@_handle_api_errors
+def segments_get(
+    segment_id: int = typer.Argument(..., help="Segment identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_segment(segment_id))
+
+
+@segments_app.command("effort")
+@_handle_api_errors
+def segments_effort(
+    effort_id: int = typer.Argument(..., help="Segment effort identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_segment_effort(effort_id))
+
+
+@segments_app.command("efforts")
+@_handle_api_errors
+def segments_efforts(
+    segment_id: int = typer.Argument(..., help="Segment identifier."),
+    athlete_id: int | None = typer.Option(
+        None, help="Restrict to an athlete."
+    ),
+    start_date: datetime | None = typer.Option(
+        None,
+        "--start-date",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Start date filter (inclusive).",
+    ),
+    end_date: datetime | None = typer.Option(
+        None,
+        "--end-date",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="End date filter (inclusive).",
+    ),
+    limit: int | None = typer.Option(None, help="Maximum efforts to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    efforts = client.get_segment_efforts(
+        segment_id,
+        athlete_id=athlete_id,
+        start_date_local=start_date,
+        end_date_local=end_date,
+        limit=limit,
+    )
+    _emit_result(ctx, efforts)
+
+
+@segments_app.command("starred")
+@_handle_api_errors
+def segments_starred(
+    limit: int | None = typer.Option(None, help="Maximum starred segments."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_starred_segments(limit=limit))
+
+
+@segments_app.command("athlete-starred")
+@_handle_api_errors
+def segments_athlete_starred(
+    athlete_id: int = typer.Argument(..., help="Athlete identifier."),
+    limit: int | None = typer.Option(None, help="Maximum starred segments."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx, client.get_athlete_starred_segments(athlete_id, limit=limit)
+    )
+
+
+@segments_app.command("explore")
+@_handle_api_errors
+def segments_explore(
+    south_lat: float = typer.Option(..., help="South latitude."),
+    west_lng: float = typer.Option(..., help="West longitude."),
+    north_lat: float = typer.Option(..., help="North latitude."),
+    east_lng: float = typer.Option(..., help="East longitude."),
+    activity_type: str | None = typer.Option(None, help="running or riding."),
+    min_cat: int | None = typer.Option(None, help="Minimum climb category."),
+    max_cat: int | None = typer.Option(None, help="Maximum climb category."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    segments = client.explore_segments(
+        bounds=(south_lat, west_lng, north_lat, east_lng),
+        activity_type=activity_type,
+        min_cat=min_cat,
+        max_cat=max_cat,
+    )
+    _emit_result(ctx, segments)
+
+
+@segments_app.command("streams")
+@_handle_api_errors
+def segments_streams(
+    segment_id: int = typer.Argument(..., help="Segment identifier."),
+    stream_types: list[str] | None = typer.Option(
+        None,
+        "--stream",
+        "-s",
+        help="Stream types to request (repeat option).",
+    ),
+    resolution: str | None = typer.Option(None, help="Stream resolution."),
+    series_type: str | None = typer.Option(None, help="Series type."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.get_segment_streams(
+            segment_id,
+            types=stream_types or None,
+            resolution=resolution,
+            series_type=series_type,
+        ),
+    )
+
+
+@segments_app.command("effort-streams")
+@_handle_api_errors
+def segments_effort_streams(
+    effort_id: int = typer.Argument(..., help="Segment effort identifier."),
+    stream_types: list[str] | None = typer.Option(
+        None,
+        "--stream",
+        "-s",
+        help="Stream types to request (repeat option).",
+    ),
+    resolution: str | None = typer.Option(None, help="Stream resolution."),
+    series_type: str | None = typer.Option(None, help="Series type."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.get_effort_streams(
+            effort_id,
+            types=stream_types or None,
+            resolution=resolution,
+            series_type=series_type,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route operations
+# ---------------------------------------------------------------------------
+
+
+@routes_app.command("list")
+@_handle_api_errors
+def routes_list(
+    athlete_id: int | None = typer.Option(
+        None,
+        help="Athlete identifier (defaults to authenticated athlete).",
+    ),
+    limit: int | None = typer.Option(None, help="Maximum routes to return."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_routes(athlete_id=athlete_id, limit=limit))
+
+
+@routes_app.command("get")
+@_handle_api_errors
+def routes_get(
+    route_id: int = typer.Argument(..., help="Route identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_route(route_id))
+
+
+@routes_app.command("streams")
+@_handle_api_errors
+def routes_streams(
+    route_id: int = typer.Argument(..., help="Route identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_route_streams(route_id))
+
+
+# ---------------------------------------------------------------------------
+# Gear operations
+# ---------------------------------------------------------------------------
+
+
+@gear_app.command("get")
+@_handle_api_errors
+def gear_get(
+    gear_id: str = typer.Argument(..., help="Gear identifier."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_gear(gear_id))
+
+
+# ---------------------------------------------------------------------------
+# Subscription operations
+# ---------------------------------------------------------------------------
+
+
+@subscriptions_app.command("create")
+@_handle_api_errors
+def subscriptions_create(
+    client_id: int = typer.Option(..., help="Application client id."),
+    client_secret: str = typer.Option(..., help="Application client secret."),
+    callback_url: str = typer.Option(
+        ..., help="Callback URL registered with Strava."
+    ),
+    verify_token: str = typer.Option(
+        model.Subscription.VERIFY_TOKEN_DEFAULT,
+        help="Verify token to validate callback requests.",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(
+        ctx,
+        client.create_subscription(
+            client_id=client_id,
+            client_secret=client_secret,
+            callback_url=callback_url,
+            verify_token=verify_token,
+        ),
+    )
+
+
+@subscriptions_app.command("list")
+@_handle_api_errors
+def subscriptions_list(
+    client_id: int = typer.Option(..., help="Application client id."),
+    client_secret: str = typer.Option(..., help="Application client secret."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.list_subscriptions(client_id, client_secret))
+
+
+@subscriptions_app.command("delete")
+@_handle_api_errors
+def subscriptions_delete(
+    subscription_id: int = typer.Argument(
+        ..., help="Subscription identifier."
+    ),
+    client_id: int = typer.Option(..., help="Application client id."),
+    client_secret: str = typer.Option(..., help="Application client secret."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    client.delete_subscription(
+        subscription_id=subscription_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    _emit_result(ctx, {"message": f"Deleted subscription {subscription_id}."})
+
+
+@subscriptions_app.command("challenge")
+@_handle_api_errors
+def subscriptions_challenge(
+    payload_file: Path | None = typer.Option(
+        None, help="Path to JSON payload received from Strava."
+    ),
+    payload: str | None = typer.Option(None, help="Raw JSON payload string."),
+    verify_token: str = typer.Option(
+        model.Subscription.VERIFY_TOKEN_DEFAULT,
+        help="Verify token configured with Strava.",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    if payload_file:
+        raw = json.loads(payload_file.read_text())
+    elif payload:
+        raw = json.loads(payload)
+    else:
+        raw = json.loads(typer.prompt("Paste the JSON payload"))
+    _emit_result(
+        ctx,
+        client.handle_subscription_callback(raw, verify_token=verify_token),
+    )
+
+
+@subscriptions_app.command("process-update")
+@_handle_api_errors
+def subscriptions_process_update(
+    payload_file: Path | None = typer.Option(
+        None, help="Path to JSON update payload from Strava."
+    ),
+    payload: str | None = typer.Option(None, help="Raw JSON payload string."),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    if payload_file:
+        raw = json.loads(payload_file.read_text())
+    elif payload:
+        raw = json.loads(payload)
+    else:
+        raw = json.loads(typer.prompt("Paste the JSON payload"))
+    _emit_result(ctx, client.handle_subscription_update(raw))
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatible root commands
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+@_handle_api_errors
+def whoami() -> None:
+    athlete_profile()
+
+
+@app.command("athlete-stats")
+@_handle_api_errors
+def root_athlete_stats(
+    athlete_id: int | None = typer.Option(
+        None,
+        help="Optional athlete id (defaults to authenticated athlete).",
+    ),
+) -> None:
+    ctx = _current_context()
+    client = _get_client()
+    _emit_result(ctx, client.get_athlete_stats(athlete_id=athlete_id))
+
+
+@app.command("activities-recent")
+@_handle_api_errors
+def activities_recent(
+    limit: int = typer.Option(
+        20, "--limit", min=1, help="Number of activities to fetch."
+    ),
+    before: datetime | None = typer.Option(
+        None,
+        "--before",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Only include activities that start before this timestamp (UTC).",
+    ),
+    after: datetime | None = typer.Option(
+        None,
+        "--after",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"],
+        help="Only include activities that start after this timestamp (UTC).",
+    ),
+) -> None:
+    activities_list(limit=limit, before=before, after=after)
+
+
+@app.command("activity")
+@_handle_api_errors
+def root_activity(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    include_all_efforts: bool = typer.Option(
+        False,
+        "--include-all-efforts/--no-include-all-efforts",
+        help="Request all efforts for the activity (may be slower).",
+    ),
+) -> None:
+    activities_get(
+        activity_id=activity_id, include_all_efforts=include_all_efforts
+    )
+
+
+@app.command("activity-streams")
+@_handle_api_errors
+def root_activity_streams(
+    activity_id: int = typer.Argument(..., help="Activity identifier."),
+    stream_types: list[str] | None = typer.Option(
+        None,
+        "--stream",
+        "-s",
+        help="Stream types to request (repeat option).",
+    ),
+    resolution: str | None = typer.Option(None, help="Stream resolution."),
+    series_type: str | None = typer.Option(None, help="Series type."),
+) -> None:
+    activities_streams(
+        activity_id=activity_id,
+        stream_types=stream_types,
+        resolution=resolution,
+        series_type=series_type,
+    )
+
+
+@app.command("athlete-zones")
+@_handle_api_errors
+def root_athlete_zones() -> None:
+    athlete_zones()
+
+
+@app.command("athlete-clubs")
+@_handle_api_errors
+def root_athlete_clubs(
+    limit: int | None = typer.Option(None, help="Maximum clubs to return."),
+) -> None:
+    athlete_clubs(limit=limit)
+
+
+@app.command("segments-explore")
+@_handle_api_errors
+def root_segments_explore(
+    south_lat: float = typer.Option(..., help="South latitude."),
+    west_lng: float = typer.Option(..., help="West longitude."),
+    north_lat: float = typer.Option(..., help="North latitude."),
+    east_lng: float = typer.Option(..., help="East longitude."),
+    activity_type: str | None = typer.Option(None, help="running or riding."),
+    min_cat: int | None = typer.Option(None, help="Minimum climb category."),
+    max_cat: int | None = typer.Option(None, help="Maximum climb category."),
+) -> None:
+    segments_explore(
+        south_lat=south_lat,
+        west_lng=west_lng,
+        north_lat=north_lat,
+        east_lng=east_lng,
+        activity_type=activity_type,
+        min_cat=min_cat,
+        max_cat=max_cat,
+    )
+
+
+def main_entry() -> None:  # pragma: no cover
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main_entry()

--- a/src/stravalib/tests/test_cli.py
+++ b/src/stravalib/tests/test_cli.py
@@ -1,0 +1,924 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+import stravalib.cli as cli
+from stravalib import exc
+
+
+class FakeAthlete(BaseModel):
+    id: int
+    firstname: str
+
+
+class FakeActivity(BaseModel):
+    id: int
+    name: str
+
+
+class FakeStats(BaseModel):
+    biggest_ride_distance: int
+
+
+class FakeSegment(BaseModel):
+    id: int
+    name: str
+
+
+class FakeGear(BaseModel):
+    id: str
+    name: str
+
+
+class StubUploader:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.upload_id = 404
+        self.external_id = "upload.fit"
+        self.activity_id: int | None = None
+        self.status = "processing"
+        self.error: str | None = None
+        self._photo_metadata: Any = None
+
+    @property
+    def photo_metadata(self) -> Any:
+        return self._photo_metadata
+
+    @photo_metadata.setter
+    def photo_metadata(self, value: Any) -> None:
+        self._photo_metadata = value
+
+    def wait(self, *_args: Any, **_kwargs: Any) -> FakeActivity:
+        self.activity_id = 555
+        return FakeActivity(id=555, name="Polled Activity")
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.access_token: str | None = None
+        self.refresh_token: str | None = None
+        self.token_expires: int | None = None
+        self.protocol = SimpleNamespace(rate_limiter="original")
+
+    def _record(self, action: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((action, args, kwargs))
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+    def authorization_url(self, *args: Any, **kwargs: Any) -> str:
+        self._record("authorization_url", *args, **kwargs)
+        return "https://example.com/auth"
+
+    def exchange_code_for_token(self, *args: Any, **kwargs: Any) -> Any:
+        self._record("exchange_code_for_token", *args, **kwargs)
+        info = {"access_token": "tok", "refresh_token": "ref", "expires_at": 1}
+        if kwargs.get("return_athlete"):
+            return info, FakeAthlete(id=7, firstname="Tester")
+        return info
+
+    def refresh_access_token(
+        self, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        self._record("refresh_access_token", *args, **kwargs)
+        return {"access_token": "tok", "refresh_token": "ref", "expires_at": 2}
+
+    def deauthorize(self) -> None:
+        self._record("deauthorize")
+
+    # ------------------------------------------------------------------
+    # Athlete
+    # ------------------------------------------------------------------
+    def get_athlete(self) -> FakeAthlete:
+        self._record("get_athlete")
+        return FakeAthlete(id=101, firstname="Unit")
+
+    def update_athlete(self, **kwargs: Any) -> FakeAthlete:
+        self._record("update_athlete", **kwargs)
+        return FakeAthlete(id=101, firstname="Unit")
+
+    def get_athlete_zones(self) -> dict[str, Any]:
+        self._record("get_athlete_zones")
+        return {"heartrate": []}
+
+    def get_athlete_stats(self, athlete_id: int | None = None) -> FakeStats:
+        self._record("get_athlete_stats", athlete_id)
+        return FakeStats(biggest_ride_distance=42)
+
+    def get_athlete_koms(
+        self, athlete_id: int, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_athlete_koms", athlete_id, limit)
+        return [{"id": 1}]
+
+    def get_athlete_clubs(
+        self, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_athlete_clubs", limit)
+        return [{"id": 2}]
+
+    # ------------------------------------------------------------------
+    # Activities
+    # ------------------------------------------------------------------
+    def get_activities(self, **kwargs: Any) -> list[FakeActivity]:
+        self._record("get_activities", **kwargs)
+        return [FakeActivity(id=202, name="Ride")]
+
+    def get_activity(
+        self, activity_id: int, include_all_efforts: bool = False
+    ) -> FakeActivity:
+        self._record("get_activity", activity_id, include_all_efforts)
+        return FakeActivity(id=activity_id, name="Detailed")
+
+    def create_activity(self, **kwargs: Any) -> FakeActivity:
+        self._record("create_activity", **kwargs)
+        return FakeActivity(id=303, name="Created")
+
+    def update_activity(self, activity_id: int, **kwargs: Any) -> FakeActivity:
+        self._record("update_activity", activity_id, **kwargs)
+        return FakeActivity(id=activity_id, name="Updated")
+
+    def upload_activity(self, *_args: Any, **_kwargs: Any) -> StubUploader:
+        self._record("upload_activity", *_args, **_kwargs)
+        return StubUploader()
+
+    def get_activity_zones(self, activity_id: int) -> list[dict[str, Any]]:
+        self._record("get_activity_zones", activity_id)
+        return [{"type": "heartrate"}]
+
+    def get_activity_comments(
+        self, *args: Any, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self._record("get_activity_comments", *args, **kwargs)
+        return [{"text": "Nice ride"}]
+
+    def get_activity_kudos(
+        self, *args: Any, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self._record("get_activity_kudos", *args, **kwargs)
+        return [{"firstname": "Fan"}]
+
+    def get_activity_photos(
+        self, *args: Any, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self._record("get_activity_photos", *args, **kwargs)
+        return [{"id": "photo"}]
+
+    def get_activity_laps(self, activity_id: int) -> list[dict[str, Any]]:
+        self._record("get_activity_laps", activity_id)
+        return [{"lap": 1}]
+
+    def get_activity_streams(
+        self, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        self._record("get_activity_streams", *args, **kwargs)
+        return {"watts": {"type": "watts", "data": [1, 2]}}
+
+    # ------------------------------------------------------------------
+    # Clubs
+    # ------------------------------------------------------------------
+    def get_club(self, club_id: int) -> dict[str, Any]:
+        self._record("get_club", club_id)
+        return {"id": club_id}
+
+    def get_club_members(
+        self, club_id: int, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_club_members", club_id, limit)
+        return [{"id": 10}]
+
+    def get_club_activities(
+        self, club_id: int, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_club_activities", club_id, limit)
+        return [{"id": 20}]
+
+    def get_club_admins(
+        self, club_id: int, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_club_admins", club_id, limit)
+        return [{"id": 30}]
+
+    def join_club(self, club_id: int) -> None:
+        self._record("join_club", club_id)
+
+    def leave_club(self, club_id: int) -> None:
+        self._record("leave_club", club_id)
+
+    # ------------------------------------------------------------------
+    # Segments
+    # ------------------------------------------------------------------
+    def get_segment(self, segment_id: int) -> FakeSegment:
+        self._record("get_segment", segment_id)
+        return FakeSegment(id=segment_id, name="Segment")
+
+    def get_segment_effort(self, effort_id: int) -> dict[str, Any]:
+        self._record("get_segment_effort", effort_id)
+        return {"id": effort_id}
+
+    def get_segment_efforts(
+        self, *args: Any, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self._record("get_segment_efforts", *args, **kwargs)
+        return [{"id": 111}]
+
+    def get_starred_segments(
+        self, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_starred_segments", limit)
+        return [{"id": 222}]
+
+    def get_athlete_starred_segments(
+        self, athlete_id: int, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_athlete_starred_segments", athlete_id, limit)
+        return [{"id": 333}]
+
+    def explore_segments(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self._record("explore_segments", **kwargs)
+        return [{"id": 444}]
+
+    def get_segment_streams(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self._record("get_segment_streams", *args, **kwargs)
+        return {"latlng": {"data": []}}
+
+    def get_effort_streams(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self._record("get_effort_streams", *args, **kwargs)
+        return {"time": {"data": []}}
+
+    # ------------------------------------------------------------------
+    # Routes & Gear
+    # ------------------------------------------------------------------
+    def get_routes(
+        self, athlete_id: int | None = None, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        self._record("get_routes", athlete_id, limit)
+        return [{"id": 555}]
+
+    def get_route(self, route_id: int) -> dict[str, Any]:
+        self._record("get_route", route_id)
+        return {"id": route_id}
+
+    def get_route_streams(self, route_id: int) -> dict[str, Any]:
+        self._record("get_route_streams", route_id)
+        return {"distance": {"data": []}}
+
+    def get_gear(self, gear_id: str) -> FakeGear:
+        self._record("get_gear", gear_id)
+        return FakeGear(id=gear_id, name="Bike")
+
+    # ------------------------------------------------------------------
+    # Subscriptions
+    # ------------------------------------------------------------------
+    def create_subscription(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("create_subscription", **kwargs)
+        return {"id": 1}
+
+    def list_subscriptions(
+        self, client_id: int, client_secret: str
+    ) -> list[dict[str, Any]]:
+        self._record("list_subscriptions", client_id, client_secret)
+        return [{"id": 2}]
+
+    def delete_subscription(self, **kwargs: Any) -> None:
+        self._record("delete_subscription", **kwargs)
+
+    def handle_subscription_callback(
+        self, raw: dict[str, Any], verify_token: str = ""
+    ) -> dict[str, Any]:
+        self._record("handle_subscription_callback", raw, verify_token)
+        return {"hub.challenge": raw.get("hub.challenge", "")}
+
+    def handle_subscription_update(
+        self, raw: dict[str, Any]
+    ) -> dict[str, Any]:
+        self._record("handle_subscription_update", raw)
+        return {"received": True}
+
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def patch_uploader(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "ActivityUploader", StubUploader)
+
+
+@pytest.fixture()
+def cli_state() -> cli.CLIState:
+    return cli.CLIState(client=DummyClient())
+
+
+def _invoke(
+    args: list[str], state: cli.CLIState, tmp_path: Path | None = None
+) -> tuple[Any, DummyClient]:
+    env = {}
+    result = runner.invoke(cli.app, args, obj=state, env=env)
+    assert result.exit_code == 0, result.stdout
+    data = json.loads(result.stdout)
+    return data, state.client  # type: ignore[return-value]
+
+
+def test_auth_commands(cli_state: cli.CLIState) -> None:
+    data, client = _invoke(
+        [
+            "auth",
+            "authorization-url",
+            "--client-id",
+            "123",
+            "--redirect-uri",
+            "http://localhost/callback",
+            "--scope",
+            "read",
+            "--state",
+            "xyz",
+        ],
+        cli_state,
+    )
+    assert data["authorization_url"].startswith("https://example.com")
+    assert client.calls[-1][0] == "authorization_url"
+
+    data, client = _invoke(
+        [
+            "auth",
+            "exchange-token",
+            "--client-id",
+            "7",
+            "--client-secret",
+            "secret",
+            "--code",
+            "auth-code",
+            "--return-athlete",
+        ],
+        cli_state,
+    )
+    assert data["access_info"]["access_token"] == "tok"
+    assert data["athlete"]["firstname"] == "Tester"
+
+    data, _ = _invoke(
+        [
+            "auth",
+            "exchange-token",
+            "--client-id",
+            "7",
+            "--client-secret",
+            "secret",
+            "--code",
+            "auth-code",
+        ],
+        cli_state,
+    )
+    assert data["access_token"] == "tok"
+
+    data, client = _invoke(
+        [
+            "auth",
+            "refresh-token",
+            "--client-id",
+            "7",
+            "--client-secret",
+            "secret",
+            "--refresh-token",
+            "ref",
+        ],
+        cli_state,
+    )
+    assert data["refresh_token"] == "ref"
+
+    result = runner.invoke(cli.app, ["auth", "deauthorize"], obj=cli_state)
+    assert result.exit_code == 0
+    assert cli_state.client.calls[-1][0] == "deauthorize"
+
+
+def test_athlete_commands(cli_state: cli.CLIState, tmp_path: Path) -> None:
+    data, client = _invoke(["athlete", "profile"], cli_state)
+    assert data["firstname"] == "Unit"
+
+    data, client = _invoke(
+        [
+            "athlete",
+            "update",
+            "--city",
+            "Austin",
+            "--state",
+            "Texas",
+            "--country",
+            "USA",
+            "--sex",
+            "M",
+            "--weight",
+            "82.5",
+        ],
+        cli_state,
+    )
+    assert client.calls[-1][0] == "update_athlete"
+
+    data, _ = _invoke(["athlete", "zones"], cli_state)
+    assert "heartrate" in data
+
+    data, _ = _invoke(["athlete", "stats", "--athlete-id", "99"], cli_state)
+    assert data["biggest_ride_distance"] == 42
+
+    data, _ = _invoke(
+        ["athlete", "koms", "--athlete-id", "123", "--limit", "5"], cli_state
+    )
+    assert data[0]["id"] == 1
+
+    data, _ = _invoke(["athlete", "clubs", "--limit", "3"], cli_state)
+    assert data[0]["id"] == 2
+
+    output_file = tmp_path / "athlete.json"
+    result = runner.invoke(
+        cli.app,
+        ["--output-file", str(output_file), "athlete", "profile"],
+        obj=cli_state,
+    )
+    assert result.exit_code == 0
+    saved = json.loads(output_file.read_text())
+    assert saved["id"] == 101
+
+
+def test_activities_commands(cli_state: cli.CLIState, tmp_path: Path) -> None:
+    before = "2025-01-02T00:00"
+    after = "2025-01-01T00:00"
+    data, client = _invoke(
+        [
+            "activities",
+            "list",
+            "--limit",
+            "3",
+            "--before",
+            before,
+            "--after",
+            after,
+        ],
+        cli_state,
+    )
+    assert data[0]["id"] == 202
+    assert client.calls[-1][0] == "get_activities"
+
+    data, _ = _invoke(["activities", "get", "123"], cli_state)
+    assert data["id"] == 123
+
+    data, _ = _invoke(
+        [
+            "activities",
+            "create",
+            "--name",
+            "Commute",
+            "--start-date",
+            "2025-03-01T07:30",
+            "--elapsed-time",
+            "3600",
+            "--sport-type",
+            "Ride",
+            "--description",
+            "Morning ride",
+            "--distance",
+            "1234",
+            "--trainer",
+        ],
+        cli_state,
+    )
+    assert data["name"] == "Created"
+
+    data, _ = _invoke(
+        [
+            "activities",
+            "update",
+            "123",
+            "--name",
+            "Updated",
+            "--activity-type",
+            "Run",
+            "--private",
+            "--commute",
+            "--trainer",
+            "--gear-id",
+            "123",
+            "--device-name",
+            "computer",
+            "--hide-from-home",
+        ],
+        cli_state,
+    )
+    assert data["name"] == "Updated"
+
+    data, _ = _invoke(["activities", "zones", "123"], cli_state)
+    assert data[0]["type"] == "heartrate"
+
+    data, _ = _invoke(
+        ["activities", "comments", "123", "--markdown"], cli_state
+    )
+    assert data[0]["text"] == "Nice ride"
+
+    data, _ = _invoke(
+        ["activities", "kudos", "123", "--limit", "2"], cli_state
+    )
+    assert data[0]["firstname"] == "Fan"
+
+    data, _ = _invoke(
+        ["activities", "photos", "123", "--size", "256", "--only-instagram"],
+        cli_state,
+    )
+    assert data[0]["id"] == "photo"
+
+    data, _ = _invoke(["activities", "laps", "123"], cli_state)
+    assert data[0]["lap"] == 1
+
+    data, _ = _invoke(
+        [
+            "activities",
+            "streams",
+            "123",
+            "--stream",
+            "watts",
+            "--resolution",
+            "low",
+        ],
+        cli_state,
+    )
+    assert "watts" in data
+
+    activity_file = tmp_path / "activity.fit"
+    activity_file.write_bytes(b"data")
+    data, _ = _invoke(
+        [
+            "activities",
+            "upload",
+            str(activity_file),
+            "--data-type",
+            "fit",
+            "--name",
+            "Ride",
+        ],
+        cli_state,
+    )
+    assert data["upload_id"] == 404
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "activities",
+            "upload",
+            str(activity_file),
+            "--data-type",
+            "fit",
+            "--poll",
+            "--timeout",
+            "0.1",
+            "--poll-interval",
+            "0.1",
+        ],
+        obj=cli_state,
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["activity"]["id"] == 555
+
+
+def test_club_commands(cli_state: cli.CLIState) -> None:
+    data, _ = _invoke(["clubs", "get", "456"], cli_state)
+    assert data["id"] == 456
+
+    data, _ = _invoke(["clubs", "members", "456", "--limit", "3"], cli_state)
+    assert data[0]["id"] == 10
+
+    data, _ = _invoke(["clubs", "activities", "456"], cli_state)
+    assert data[0]["id"] == 20
+
+    data, _ = _invoke(["clubs", "admins", "456"], cli_state)
+    assert data[0]["id"] == 30
+
+    result = runner.invoke(cli.app, ["clubs", "join", "456"], obj=cli_state)
+    assert result.exit_code == 0
+    result = runner.invoke(cli.app, ["clubs", "leave", "456"], obj=cli_state)
+    assert result.exit_code == 0
+
+
+def test_segment_and_route_commands(cli_state: cli.CLIState) -> None:
+    data, _ = _invoke(["segments", "get", "789"], cli_state)
+    assert data["id"] == 789
+
+    data, _ = _invoke(["segments", "effort", "321"], cli_state)
+    assert data["id"] == 321
+
+    data, _ = _invoke(
+        [
+            "segments",
+            "efforts",
+            "789",
+            "--athlete-id",
+            "5",
+            "--start-date",
+            "2025-04-01",
+            "--end-date",
+            "2025-04-02",
+            "--limit",
+            "2",
+        ],
+        cli_state,
+    )
+    assert data[0]["id"] == 111
+
+    data, _ = _invoke(["segments", "starred", "--limit", "2"], cli_state)
+    assert data[0]["id"] == 222
+
+    data, _ = _invoke(
+        ["segments", "athlete-starred", "5", "--limit", "2"], cli_state
+    )
+    assert data[0]["id"] == 333
+
+    data, _ = _invoke(
+        [
+            "segments",
+            "explore",
+            "--south-lat",
+            "29.6",
+            "--west-lng",
+            "-95.8",
+            "--north-lat",
+            "29.9",
+            "--east-lng",
+            "-95.1",
+        ],
+        cli_state,
+    )
+    assert data[0]["id"] == 444
+
+    data, _ = _invoke(
+        ["segments", "streams", "789", "--stream", "latlng"], cli_state
+    )
+    assert "latlng" in data
+
+    data, _ = _invoke(
+        ["segments", "effort-streams", "321", "--stream", "time"], cli_state
+    )
+    assert "time" in data
+
+    data, _ = _invoke(
+        ["routes", "list", "--athlete-id", "12", "--limit", "4"], cli_state
+    )
+    assert data[0]["id"] == 555
+
+    data, _ = _invoke(["routes", "get", "12"], cli_state)
+    assert data["id"] == 12
+
+    data, _ = _invoke(["routes", "streams", "12"], cli_state)
+    assert "distance" in data
+
+    data, _ = _invoke(["gear", "get", "bike"], cli_state)
+    assert data["name"] == "Bike"
+
+
+def test_subscription_commands(
+    cli_state: cli.CLIState, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "create",
+            "--client-id",
+            "1",
+            "--client-secret",
+            "sec",
+            "--callback-url",
+            "https://example.com",
+            "--verify-token",
+            "token",
+        ],
+        cli_state,
+    )
+    assert data["id"] == 1
+
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "list",
+            "--client-id",
+            "1",
+            "--client-secret",
+            "sec",
+        ],
+        cli_state,
+    )
+    assert data[0]["id"] == 2
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "subscriptions",
+            "delete",
+            "9",
+            "--client-id",
+            "1",
+            "--client-secret",
+            "sec",
+        ],
+        obj=cli_state,
+    )
+    assert result.exit_code == 0
+
+    challenge_payload = json.dumps({"hub.challenge": "abc"})
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "challenge",
+            "--payload",
+            challenge_payload,
+            "--verify-token",
+            "token",
+        ],
+        cli_state,
+    )
+    assert data["hub.challenge"] == "abc"
+
+    update_payload = json.dumps({"id": 1})
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "process-update",
+            "--payload",
+            update_payload,
+        ],
+        cli_state,
+    )
+    assert data["received"] is True
+
+    challenge_file = tmp_path / "challenge.json"
+    challenge_file.write_text(json.dumps({"hub.challenge": "file"}))
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "challenge",
+            "--payload-file",
+            str(challenge_file),
+        ],
+        cli_state,
+    )
+    assert data["hub.challenge"] == "file"
+
+    monkeypatch.setattr(
+        cli.typer, "prompt", lambda _: '{"hub.challenge": "prompt"}'
+    )
+    data, _ = _invoke(["subscriptions", "challenge"], cli_state)
+    assert data["hub.challenge"] == "prompt"
+
+    update_file = tmp_path / "update.json"
+    update_file.write_text(json.dumps({"id": 2}))
+    data, _ = _invoke(
+        [
+            "subscriptions",
+            "process-update",
+            "--payload-file",
+            str(update_file),
+        ],
+        cli_state,
+    )
+    assert data["received"] is True
+
+    monkeypatch.setattr(cli.typer, "prompt", lambda _: '{"id": 3}')
+    data, _ = _invoke(["subscriptions", "process-update"], cli_state)
+    assert data["received"] is True
+
+
+def test_root_aliases(cli_state: cli.CLIState) -> None:
+    for command in (
+        ["whoami"],
+        ["athlete-stats"],
+        ["athlete-zones"],
+        ["athlete-clubs"],
+        ["activities-recent"],
+        ["activity", "12"],
+        ["activity-streams", "12"],
+        [
+            "segments-explore",
+            "--south-lat",
+            "29.6",
+            "--west-lng",
+            "-95.8",
+            "--north-lat",
+            "29.9",
+            "--east-lng",
+            "-95.1",
+        ],
+    ):
+        result = runner.invoke(cli.app, command, obj=cli_state)
+        assert result.exit_code == 0
+
+
+def test_main_initialises_state_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dummy = DummyClient()
+
+    monkeypatch.setattr(cli, "_build_client", lambda **_: dummy)
+    result = runner.invoke(cli.app, ["athlete", "profile"])
+    assert result.exit_code == 0
+    assert dummy.calls[-1][0] == "get_athlete"
+
+
+def test_main_updates_existing_client(cli_state: cli.CLIState) -> None:
+    client = cli_state.client
+    assert client is not None
+    result = runner.invoke(
+        cli.app,
+        [
+            "--access-token",
+            "newtok",
+            "--refresh-token",
+            "newref",
+            "--token-expires",
+            "321",
+            "--no-rate-limit",
+            "athlete",
+            "profile",
+        ],
+        obj=cli_state,
+    )
+    assert result.exit_code == 0
+    assert client.access_token == "newtok"
+    assert client.refresh_token == "newref"
+    assert client.token_expires == 321
+    assert client.protocol.rate_limiter is cli._noop_rate_limiter
+
+
+def test_get_client_errors_when_build_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "_build_client", lambda **_: None)
+    result = runner.invoke(cli.app, ["athlete", "profile"])
+    assert result.exit_code == 1
+    assert "not initialised" in result.stderr
+
+
+def test_prepare_result_helpers(tmp_path: Path) -> None:
+    iterator = cli.BatchedResultsIterator(
+        entity=FakeActivity,
+        result_fetcher=lambda **_: [{"id": 1, "name": "Iterator"}],
+        bind_client=None,
+        limit=1,
+    )
+    prepared = cli._prepare_result(iterator)
+    assert prepared[0]["name"] == "Iterator"
+
+    prepared_gen = cli._prepare_result((x for x in [1, 2]))
+    assert prepared_gen == [1, 2]
+
+    dt = datetime(2025, 1, 1)
+    td = timedelta(seconds=30)
+    sample_path = tmp_path / "sample.txt"
+    assert cli._json_default(dt).startswith("2025-01-01")
+    assert cli._json_default(td) == 30
+    assert cli._json_default(sample_path) == str(sample_path)
+    assert cli._json_default(5) == 5
+    assert cli._noop_rate_limiter({}, "GET") is None
+
+
+def test_build_client_factory() -> None:
+    client = cli._build_client(
+        access_token="tok",
+        refresh_token="ref",
+        token_expires=10,
+        rate_limit=True,
+    )
+    assert client.access_token == "tok"
+    assert client.refresh_token == "ref"
+
+    secondary = cli._build_client(
+        access_token=None,
+        refresh_token=None,
+        token_expires=None,
+        rate_limit=False,
+    )
+    assert secondary.refresh_token is None
+
+
+def test_error_handling(cli_state: cli.CLIState) -> None:
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise exc.Fault("Boom")
+
+    cli_state.client.get_athlete = boom  # type: ignore[assignment]
+    result = runner.invoke(cli.app, ["athlete", "profile"], obj=cli_state)
+    assert result.exit_code == 1
+    assert "Strava API error" in result.stderr
+
+
+def test_error_handling_http(cli_state: cli.CLIState) -> None:
+    from requests import exceptions as requests_exceptions
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise requests_exceptions.RequestException("boom")
+
+    cli_state.client.get_athlete = boom  # type: ignore[assignment]
+    result = runner.invoke(cli.app, ["athlete", "profile"], obj=cli_state)
+    assert result.exit_code == 1
+    assert "HTTP error" in result.stderr


### PR DESCRIPTION
This makes stravalib easier to use outside pure Python code—shell scripts, automation pipelines, and AI agents can now call the CLI directly without re-implementing the API client.

## Summary
- Provide a Typer-powered CLI that mirrors the entire `Client` surface area, including uploads with polling and subscription helpers.
- Document usage via a new CLI quick-start guide (`docs/get-started/cli.md`) and expand the README / docs index.
- Backfill comprehensive tests for every CLI command and utility, driving `stravalib.cli` to 100% coverage.

## Testing
- uv run pytest
- uv run pytest --cov=stravalib.cli --cov-report=term-missing src/stravalib/tests/test_cli.py
- uv run ruff check .

## Documentation
- README.md
- docs/get-started/index.md
- docs/get-started/cli.md

## Additional Notes
- Added the `activities-recent` root alias to avoid Typer namespace conflicts while keeping a concise command for listing recent activities.
- The CLI respects existing environment variables (`STRAVA_ACCESS_TOKEN`, `STRAVA_REFRESH_TOKEN`, `STRAVA_TOKEN_EXPIRES_AT`, etc.) to minimize setup friction.
- Happy to adjust scope, naming, or doc placement based on maintainer feedback.
