### PR TITLE
enh: drop python 3.10

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,7 +38,7 @@ body:
     attributes:
       label: What version of python or you running?
       description: >
-        Example: 3.10.12
+        Example: 3.11
       placeholder: >
         Enter the version here.
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
   build-doc:
     runs-on: ubuntu-latest
     env:
-      PYTHON-VERSION: "3.11"
+      PYTHON-VERSION: "3.12"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ env.PYTHON-VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Upgrade pip & install nox
         run: |
           # install pip=>20.1 to use "pip cache dir"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON-VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Upgrade pip & install nox
         run: |
           # install pip=>20.1 to use "pip cache dir"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
           path: ${{ steps.set_variables.outputs.PIP_CACHE }}
           key: ${{ runner.os }}-pip-${{ steps.set_variables.outputs.PY }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           path: ${{ steps.set_variables.outputs.PIP_CACHE }}
           key: ${{ runner.os }}-pip-${{ steps.set_variables.outputs.PY }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -41,7 +41,7 @@ jobs:
           path: ${{ steps.set_variables.outputs.PIP_CACHE }}
           key: ubuntu-latest-pip-${{ steps.set_variables.outputs.PY }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           path: ${{ steps.set_variables.outputs.PIP_CACHE }}
           key: ubuntu-latest-pip-${{ steps.set_variables.outputs.PY }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: black
         entry: bash -c 'black "$@"; git add -u' --
-        language_version: python3.10
+        language_version: python3.12
         args: ["--line-length=79"]
 
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,11 +8,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-<<<<<<< HEAD
     python: "3.12"
-=======
-    python: "3.11"
->>>>>>> 7f6eeee (enh: drop python 3.10)
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,11 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
+<<<<<<< HEAD
     python: "3.12"
+=======
+    python: "3.11"
+>>>>>>> 7f6eeee (enh: drop python 3.10)
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and quantities through the [Python Pint library](https://pypi.org/project/Pint/)
 
 ## Dependencies
 
-- Python 3.10+
+- Python 3.11+
 - [Setuptools](https://pypi.org/project/setuptools/) for building stravalib
 - Other Python libraries (installed automatically when using pip):
      - [requests](https://pypi.org/project/requests/),

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 - Add: Strava API Change: Adds device_name (str) to SummaryActivity (@bot, #684)
 
 ### Fixed
+
+- Fix: drop support for Python 3.10 (@lwasser, #687)
 - Fix: Improve response header handling (@BPR02, #664)
 - Fix: Adds necessary permissions for update-model job (@jsamoocha, #654)
 - Chore(ci): Update and fix dependabot (@lwasser, #657)

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -229,10 +229,10 @@ skip that run and continue to the next version.
 ```bash
 
 ❯ nox -s mypy
-nox > Running session mypy-3.10
-nox > Missing interpreters will error by default on CI systems.
-nox > Session mypy-3.10 skipped: Python interpreter 3.10 not found.
 nox > Running session mypy-3.11
+nox > Missing interpreters will error by default on CI systems.
+nox > Session mypy-3.11 skipped: Python interpreter 3.11 not found.
+nox > Running session mypy-3.12
 ```
 
 ## Code format and syntax
@@ -286,10 +286,10 @@ To run tests for a specific Python version use:
 
 `nox -s tests-python-version-here`.
 
-For example, the command below runs our tests on Python 3.10 only.
+For example, the command below runs our tests on Python 3.11 only.
 
 ```bash
-nox -s tests-3.10
+nox -s tests-3.11
 ```
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ from glob import glob
 
 import nox
 
+nox.options.default_venv_backend = "uv"
 nox.options.reuse_existing_virtualenvs = False
 
 # Sphinx output and source directories
@@ -79,7 +80,7 @@ def docs_live(session):
 
 
 # Use this for venv envs nox -s test
-@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.11", "3.12", "3.13"])
 def tests(session):
     """Install requirements in a venv and run tests."""
     session.install(".[tests]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = [
   { name = "Yihong" },
   { name = "Émile Nadeau" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
@@ -44,7 +44,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -108,7 +107,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 follow_imports = "silent"
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
closes #687 

We run into issues with python 3.10 support given it doesn't support union based typing (i think? not a typing expert). so we have a few options but python3.10 is security only updates at this point and will be EOL in october 2026 so I think we should go ahead and drop support for it and add 3.14 when its ready. 

## Description


## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [ ] No, i'd like some help with tests
- [x] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

