### PR TITLE
feat: replace pytz which is eol with zoneinfo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,10 +165,11 @@ The codebase uses Pydantic v2. When working with models:
 
 Core dependencies (see pyproject.toml):
 - pint: Unit conversion
-- pytz: Timezone handling
 - arrow: Advanced datetime handling
 - requests: HTTP client
 - pydantic>=2.0: Data validation and serialization
+
+Note: Timezone handling uses the standard library `zoneinfo` module (Python 3.9+)
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Stravalib is a Python library providing easy-to-use tools for accessing and down
 
 ### Testing
 
-Run all tests across all supported Python versions (3.10-3.13):
+Run all tests across all supported Python versions (3.10-3.14):
 ```bash
 nox -s tests
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,181 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Stravalib is a Python library providing easy-to-use tools for accessing and downloading Strava data from the Strava V3 REST API. The library supports authentication, rate limiting, data access/download, and unit conversion through the Pint library.
+
+## Development Commands
+
+### Testing
+
+Run all tests across all supported Python versions (3.10-3.13):
+```bash
+nox -s tests
+```
+
+Run tests for a specific Python version:
+```bash
+nox -s tests-3.11
+```
+
+Run a single test file:
+```bash
+pytest src/stravalib/tests/unit/test_client.py
+```
+
+Run a specific test:
+```bash
+pytest src/stravalib/tests/unit/test_client.py::test_name
+```
+
+### Type Checking
+
+Run mypy type checking:
+```bash
+nox -s mypy
+```
+
+### Linting and Formatting
+
+The project uses pre-commit hooks with ruff (linting), black (formatting), and codespell (spell checking).
+
+Install pre-commit hooks:
+```bash
+pre-commit install --install-hooks
+```
+
+Run pre-commit on all files:
+```bash
+pre-commit run --all-files
+```
+
+Run a specific hook:
+```bash
+pre-commit run ruff --all-files
+```
+
+### Documentation
+
+Build docs:
+```bash
+nox -s docs
+```
+
+Build docs with live reload (for local development):
+```bash
+nox -s docs-live
+```
+
+Clean doc build artifacts:
+```bash
+nox -s docs-clean
+```
+
+### Building
+
+Build the package (creates wheel and sdist in dist/):
+```bash
+nox -s build
+```
+
+Clean build artifacts:
+```bash
+nox -s clean_build
+```
+
+## Code Architecture
+
+### Core Components
+
+**Client (`client.py`)**: Main interface for interacting with Strava V3 API. The `Client` class handles:
+- Authentication and token management (including automatic token refresh)
+- Rate limiting via `stravalib.util.limiter.RateLimiter`
+- All API method calls (activities, athletes, clubs, segments, etc.)
+- Batch iteration over paginated results via `BatchedResultsIterator`
+
+**Protocol (`protocol.py`)**: Low-level HTTP communication with Strava API. `ApiV3` class handles:
+- HTTP request execution (GET, POST, PUT, DELETE)
+- Token refresh logic when tokens expire
+- Error handling and response parsing
+- OAuth2 authorization flow
+
+**Model (`model.py`)**: Entity classes representing Strava data types (Activity, Athlete, Gear, etc.). These classes:
+- Inherit base fields from auto-generated `strava_model.py` (from official Strava API spec)
+- Add behavior: type enrichment, unit conversion, lazy loading of related entities
+- Use Pydantic v2 for validation and serialization
+- Support "bound" entities that can lazy-load related data via `bind_client()`
+
+**Strava Model (`strava_model.py`)**: Auto-generated from Strava API specification. DO NOT manually edit this file - it's generated from the official Strava Swagger/OpenAPI spec.
+
+**Unit Helper (`unit_helper.py`, `unit_registry.py`)**: Unit conversion utilities using Pint library for handling distances, speeds, elevations, etc.
+
+**Exceptions (`exc.py`)**: Custom exception classes and warning utilities for Strava API errors and unofficial/deprecated features.
+
+### Test Architecture
+
+Tests are organized into:
+- `src/stravalib/tests/unit/`: Unit tests that don't hit the real API
+- `src/stravalib/tests/integration/`: Integration tests using the API stub
+
+**Mock Fixture**: Tests use `StravaAPIMock` (in `integration/strava_api_stub.py`) to avoid hitting the real Strava API. This stub intercepts HTTP requests and returns mock responses. The `mock_strava_api` fixture in `conftest.py` provides this functionality.
+
+When writing tests:
+- Always use the mock fixtures to prevent real API calls
+- Unit tests should be fast and isolated
+- Integration tests verify end-to-end flows with mocked API responses
+
+### Authentication Flow
+
+1. Client is initialized with optional `access_token`, `refresh_token`, and `token_expires`
+2. Before each API call, `ApiV3` checks if token is expired (comparing current time to `token_expires`)
+3. If expired, automatically calls `refresh_access_token()` using `refresh_token`, `client_id`, and `client_secret` (from environment or constructor)
+4. New tokens are stored and used for subsequent requests
+
+### Rate Limiting
+
+The `Client` uses `stravalib.util.limiter.RateLimiter` by default to respect Strava's rate limits. The rate limiter:
+- Tracks requests in 15-minute and daily windows
+- Sleeps when approaching limits
+- Can be customized or disabled via constructor
+
+## Important Conventions
+
+### Code Style
+
+- Line length: 79 characters (enforced by black and ruff)
+- Type hints: Required for all function signatures (enforced by mypy with strict settings)
+- Docstrings: Use NumPy-style docstrings for public APIs
+
+### Python Version Support
+
+- Minimum: Python 3.10
+- Actively tested: 3.10, 3.11, 3.12, 3.13
+- Type checking targets 3.10+ features
+
+### Pydantic Usage
+
+The codebase uses Pydantic v2. When working with models:
+- All model classes inherit from `pydantic.BaseModel`
+- Use `field_validator` and `model_validator` for custom validation
+- Auto-generated models in `strava_model.py` are the source of truth for Strava API schema
+
+### Dependencies
+
+Core dependencies (see pyproject.toml):
+- pint: Unit conversion
+- pytz: Timezone handling
+- arrow: Advanced datetime handling
+- requests: HTTP client
+- pydantic>=2.0: Data validation and serialization
+
+## CI/CD
+
+GitHub Actions workflows:
+- `build-test.yml`: Runs pytest across all OS (Ubuntu, macOS, Windows) and Python versions
+- `type-check.yml`: Runs mypy type checking
+- `build-docs.yml`: Builds and deploys documentation to ReadTheDocs
+- `publish-pypi.yml`: Publishes package to PyPI on releases
+
+Pre-commit.ci is configured to automatically run hooks on PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,9 @@ The `Client` uses `stravalib.util.limiter.RateLimiter` by default to respect Str
 
 ### Python Version Support
 
-- Minimum: Python 3.10
-- Actively tested: 3.10, 3.11, 3.12, 3.13
-- Type checking targets 3.10+ features
+- Minimum: Python 3.11
+- Actively tested: 3.11, 3.12, 3.13, 3.14
+- Type checking targets 3.11+ features
 
 ### Pydantic Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ and quantities through the [Python Pint library](https://pypi.org/project/Pint/)
 - [Setuptools](https://pypi.org/project/setuptools/) for building stravalib
 - Other Python libraries (installed automatically when using pip):
      - [requests](https://pypi.org/project/requests/),
-     - [pytz](https://pypi.org/project/pytz/)
      - [pint](https://pypi.org/project/pint/)
      - [arrow](https://pypi.org/project/arrow/),
      - [pydantic 2.x](https://pypi.org/project/pydantic/)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add: Strava API Change: Adds device_name (str) to SummaryActivity (@bot, #684)
+- Add: replace pytz with ZoneInfo (@jsamoocha, #706)
 - Add: Support for Python 3.14 (@lwasser)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["pint", "pytz", "arrow", "requests", "pydantic>=2.0"]
+dependencies = ["pint", "arrow", "requests", "pydantic>=2.0"]
 
 [project.urls]
 documentation = "https://stravalib.readthedocs.io"
@@ -87,7 +87,6 @@ lint = [
   "pre-commit",
   "mypy",
   "types-requests",
-  "types-pytz",
   "types-Flask",
   "ruff",
   "types-python-dateutil"

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -12,7 +12,7 @@ import functools
 import logging
 import time
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +27,6 @@ from typing import (
 
 import arrow
 import pint
-import pytz
 from pydantic import BaseModel
 from requests import Session
 
@@ -342,7 +341,7 @@ class Client:
             activity_datetime = arrow.get(activity_datetime).datetime
         assert isinstance(activity_datetime, datetime)
         if activity_datetime.tzinfo:
-            activity_datetime = activity_datetime.astimezone(pytz.utc)
+            activity_datetime = activity_datetime.astimezone(timezone.utc)
 
         return calendar.timegm(activity_datetime.timetuple())
 

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -368,14 +368,9 @@ class Timezone(str):
 
         Returns
         -------
-        tzinfo or None
-            The corresponding ZoneInfo time zone object if the time zone string
+        tzinfo | None
+            The corresponding ZoneInfo instance if the time zone string
             is recognized, otherwise `None`.
-
-        Raises
-        ------
-        `ZoneInfoNotFoundError`
-            If the time zone string is not recognized.
         """
         if " " in self:
             # (GMT-08:00) America/Los_Angeles

--- a/src/stravalib/model.py
+++ b/src/stravalib/model.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, tzinfo
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
@@ -28,8 +28,8 @@ from typing import (
     Union,
     get_args,
 )
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-import pytz
 from dateutil import parser
 from dateutil.parser import ParserError
 from pydantic import (
@@ -43,7 +43,6 @@ from pydantic import (
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
-from pytz import UnknownTimeZoneError
 
 from stravalib import exc, strava_model
 from stravalib.strava_model import (
@@ -342,12 +341,12 @@ class Timezone(str):
     """A class to represent and manipulate time zone information.
 
     This class extends the built-in `str` class to include a method
-    for converting the time zone string to a pytz time zone object.
+    for converting the time zone string to a ZoneInfo time zone object.
 
     Methods
     -------
-    timezone() -> pytz._UTCclass | pytz.tzinfo.StaticTzInfo | pytz.tzinfo.DstTzInfo | None
-        Converts the time zone string to a pytz time zone object.
+    timezone() -> tzinfo | None
+        Converts the time zone string to a ZoneInfo time zone object.
 
     Examples
     --------
@@ -359,30 +358,23 @@ class Timezone(str):
     <DstTzInfo 'Europe/Amsterdam' LMT+0:18:00 STD>
     """
 
-    def timezone(
-        self,
-    ) -> (
-        pytz._UTCclass
-        | pytz.tzinfo.StaticTzInfo
-        | pytz.tzinfo.DstTzInfo
-        | None
-    ):
+    def timezone(self) -> tzinfo | None:
         """
-        Converts the time zone string to a pytz time zone object.
+        Converts the time zone string to a ZoneInfo time zone object.
 
         This method attempts to convert the time zone string, which can
         either be in the format "(GMT-08:00) America/Los_Angeles" or
-        "America/Los_Angeles", to a corresponding pytz time zone object.
+        "America/Los_Angeles", to a corresponding ZoneInfo time zone object.
 
         Returns
         -------
-        pytz._UTCclass, pytz.tzinfo.StaticTzInfo, `pytz.tzinfo.DstTzInfo`, or
-        `None`The corresponding `pytz` time zone object if the time zone string is
-        recognized, otherwise `None`.
+        tzinfo or None
+            The corresponding ZoneInfo time zone object if the time zone string
+            is recognized, otherwise `None`.
 
         Raises
         ------
-        `UnknownTimeZoneError`
+        `ZoneInfoNotFoundError`
             If the time zone string is not recognized.
         """
         if " " in self:
@@ -392,8 +384,8 @@ class Timezone(str):
             # America/Los_Angeles
             tzname = self
         try:
-            return pytz.timezone(tzname)
-        except UnknownTimeZoneError as e:
+            return ZoneInfo(tzname)
+        except ZoneInfoNotFoundError as e:
             LOGGER.warning(
                 f"Encountered unknown time zone {tzname}, returning None"
             )

--- a/src/stravalib/tests/unit/test_client_utils.py
+++ b/src/stravalib/tests/unit/test_client_utils.py
@@ -1,9 +1,8 @@
 import datetime
 import os
+from datetime import timezone
 from unittest import mock
 from urllib import parse as urlparse
-
-import pytz
 
 from stravalib.client import Client
 from stravalib.tests import RESOURCES_DIR, TestBase
@@ -15,7 +14,7 @@ class ClientUtilsTest(TestBase):
     def test_utc_datetime_to_epoch_utc_datetime_given_correct_epoch_returned(
         self,
     ):
-        dt = pytz.utc.localize(datetime.datetime(2014, 1, 1, 0, 0, 0))
+        dt = datetime.datetime(2014, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         self.assertEqual(1388534400, self.client._utc_datetime_to_epoch(dt))
 
 

--- a/src/stravalib/tests/unit/test_model.py
+++ b/src/stravalib/tests/unit/test_model.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 
 import stravalib.unit_helper as uh
 from stravalib import model
@@ -266,10 +266,10 @@ def test_extended_types_values(
 @pytest.mark.parametrize(
     "arg,expected_value",
     (
-        ("Factory", None),
-        ("(GMT+00:00) Factory", None),
-        ("Europe/Amsterdam", pytz.timezone("Europe/Amsterdam")),
-        ("(GMT+01:00) Europe/Amsterdam", pytz.timezone("Europe/Amsterdam")),
+        ("Invalid/Timezone", None),
+        ("(GMT+00:00) Invalid/Timezone", None),
+        ("Europe/Amsterdam", ZoneInfo("Europe/Amsterdam")),
+        ("(GMT+01:00) Europe/Amsterdam", ZoneInfo("Europe/Amsterdam")),
     ),
 )
 def test_timezone(arg, expected_value):


### PR DESCRIPTION
closes #706

## Description

Replaces EOL `pytz` by stdlib `ZoneInfo`

## Type of change

Select the statement best describes this pull request.

- [X] New feature (non-breaking change which adds functionality)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [X] Yes (existing tests are updated)

## Did you include your contribution to the change log?

- [X] Yes, `changelog.md` is up-to-date.
