### PR TITLE
fix: edge case bug in rate limiter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 - Docs: Add comprehensive docstrings to ActivityUploader properties (@HzaCode)
 - Docs: Add detailed DefaultRateLimiter documentation with priority level examples (@HzaCode)
 - Fix: Adds type parameters to generic Pint objects (@jsamoocha, #687)
+- Fix: Corrects rate limiter inconsistency (@jsamoocha, #615)
 
 ## v2.4
 


### PR DESCRIPTION
closes #615

## Description

This change solves a bug in the rate limiter where the short-term limit could be depleted if, at the end of the day, there are many long-term requests left.

## Type of change

Select the statement best describes this pull request.

- [X] Bug fix (non-breaking change which fixes an issue)

## Does your PR include tests

- [X] Yes

## Did you include your contribution to the change log?

- [X] Yes, `changelog.md` is up-to-date.
