### PR TITLE
Fix bool params in update_activity/upload_activity

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1000,13 +1000,13 @@ class Client:
 
         if private is not None:
             warn_param_unsupported("private")
-            params["private"] = int(private)
+            params["private"] = private
 
         if commute is not None:
-            params["commute"] = int(commute)
+            params["commute"] = commute
 
         if trainer is not None:
-            params["trainer"] = int(trainer)
+            params["trainer"] = trainer
 
         if gear_id is not None:
             params["gear_id"] = gear_id
@@ -1019,7 +1019,7 @@ class Client:
             params["device_name"] = device_name
 
         if hide_from_home is not None:
-            params["hide_from_home"] = int(hide_from_home)
+            params["hide_from_home"] = hide_from_home
 
         # Validate sport and activity types
         params = self._validate_activity_type(
@@ -1120,13 +1120,13 @@ class Client:
             params["activity_type"] = activity_type.lower()
         if private is not None:
             warn_param_unsupported("private")
-            params["private"] = int(private)
+            params["private"] = private
         if external_id is not None:
             params["external_id"] = external_id
         if trainer is not None:
-            params["trainer"] = int(trainer)
+            params["trainer"] = trainer
         if commute is not None:
-            params["commute"] = int(commute)
+            params["commute"] = commute
 
         initial_response = self.protocol.post(
             "/uploads",


### PR DESCRIPTION
## Fix: bool params incorrectly converted to int() in update_activity / upload_activity

### Problem

`update_activity()` and `upload_activity()` were converting bool parameters to `int()`:
- `params["hide_from_home"] = int(hide_from_home)` sends `"hide_from_home": 0` or `"hide_from_home": 1`
- Same for `private`, `commute`, `trainer`

Strava's API ignores `0`/`1` for boolean fields and leaves them unchanged — so `hide_from_home=False` silently does nothing.

### Fix

Pass Python `bool` values directly. When serialized via `requests` as query params or JSON body, `True`/`False` are correctly encoded and recognized by Strava's API.

### Changes

- `src/stravalib/client.py`: Removed `int()` wrapper from 7 boolean param assignments across both methods

### Testing

- Manual test confirmed the fix: `hide_from_home=False` now correctly sends `false` not `0`
- The fix affects both `update_activity()` and `upload_activity()` paths

### Related

Fixes #716
