### PR TITLE
716 - Fix hide_from_home when updating activity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Add: Support for Python 3.14 (@lwasser)
 
 ### Fixed
+- Fix: Updating an activity to set hide from home, commute, or trainer to false will update correctly (@Taur1ne, #716)
 - Fix: Remove false warning about response headers on authentication calls (@BPR02, #667)
 - Fix: drop support for Python 3.10 (@lwasser, #687)
 - Fix: Improve response header handling (@BPR02, #664)

--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1003,10 +1003,10 @@ class Client:
             params["private"] = int(private)
 
         if commute is not None:
-            params["commute"] = int(commute)
+            params["commute"] = commute
 
         if trainer is not None:
-            params["trainer"] = int(trainer)
+            params["trainer"] = trainer
 
         if gear_id is not None:
             params["gear_id"] = gear_id
@@ -1019,7 +1019,7 @@ class Client:
             params["device_name"] = device_name
 
         if hide_from_home is not None:
-            params["hide_from_home"] = int(hide_from_home)
+            params["hide_from_home"] = hide_from_home
 
         # Validate sport and activity types
         params = self._validate_activity_type(

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -656,7 +656,6 @@ class ApiV3(metaclass=abc.ABCMeta):
             params=params,
             method="PUT",
             check_for_errors=check_for_errors,
-            # url, json=params, method="PUT", check_for_errors=check_for_errors
         )
 
     def delete(

--- a/src/stravalib/protocol.py
+++ b/src/stravalib/protocol.py
@@ -216,7 +216,12 @@ class ApiV3(metaclass=abc.ABCMeta):
                 f"Invalid/unsupported request method specified: {method}"
             )
 
-        raw = requester(url, params=params)  # type: ignore[operator]
+        if method.upper() == "PUT":
+            token = {"access_token": params["access_token"]}
+            raw = requester(url, params=token, json=params)
+        else:
+            raw = requester(url, params=params)  # type: ignore[operator]
+
         # Rate limits are taken from HTTP response headers
         # https://developers.strava.com/docs/rate-limits/
         if "/oauth/" not in url:
@@ -647,7 +652,11 @@ class ApiV3(metaclass=abc.ABCMeta):
         url = url.format(**kwargs)
         params = {k: v for k, v in kwargs.items() if k not in referenced}
         return self._request(
-            url, params=params, method="PUT", check_for_errors=check_for_errors
+            url,
+            params=params,
+            method="PUT",
+            check_for_errors=check_for_errors,
+            # url, json=params, method="PUT", check_for_errors=check_for_errors
         )
 
     def delete(


### PR DESCRIPTION
closes #716

_The text above will ensure the issue will be closed when this PR is merged_

<!--- * If this pr does not address an open issue  in the repository, please be sure
to explain what this pull request fixes or does. We prefer to discuss changes in issues first, to just ensure we are all on the same page about the change being proposed.

* If this is a technical code change, please be sure that you have [read our contributing guide.](https://stravalib.readthedocs.io/en/latest/contributing/how-to-contribute.html)
-->

## Description

<!--- Please describe changes made in this pull request in detail -->

The Strava API expects `hide_from_home`, `commute`, and `trainer` values to be type bool when updating an activity. See https://developers.strava.com/docs/reference/#api-models-UpdatableActivity

These types are different than when creating an activity for `commute` and `trainer`. See https://developers.strava.com/docs/reference/#api-Activities-createActivity

The PUT function needs to send JSON serialized values to the Strava API which the previous code was not doing. When `hide_from_home` was being sent as values `1`, `0`, `True` or `False`, the Strava API would then set the value to `true` for the activity since they were not JSON literal values. The value sent over the wire needs to be `true` or `false` to be correctly set. 

 

## Type of change

Select the statement best describes this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
- [ ] This is a infrastructure update (docs, ci, etc)
- [ ] Other (please describe)

## Does your PR include tests

If you are fixing a bug or adding a feature, we appreciate (but do not require)
tests to support whatever fix of feature you're implementing.

- [ ] Yes
- [x] No, i'd like some help with tests
- [ ] This change doesn't require tests

## Did you include your contribution to the change log?

- [x] Yes, `changelog.md` is up-to-date.

_If you are having a hard time getting the tests to run correctly feel free to
ping one of the maintainers here!_

<!---
If you are a stravalib maintainer submitting a PR in preparation for a new release
you can use the pull request release template:

[https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md](https://github.com/stravalib/stravalib/compare/main...branch-name-here?template=release-pull-request-template.md). Be sure to modify
the text "branch-name-here" in the above url to apply the release template.
-->
