### PR TITLE
fix: pass boolean hide_from_home directly instead of int

### DIFF
--- a/src/stravalib/client.py
+++ b/src/stravalib/client.py
@@ -1019,7 +1019,7 @@ class Client:
             params["device_name"] = device_name
 
         if hide_from_home is not None:
-            params["hide_from_home"] = int(hide_from_home)
+            params["hide_from_home"] = hide_from_home
 
         # Validate sport and activity types
         params = self._validate_activity_type(


### PR DESCRIPTION
## Summary

Fixes #716

## Problem

The `hide_from_home` parameter was being converted to int:
- `False` → `0`
- `True` → `1`

However, Strava API expects a boolean value. When receiving `0`, Strava incorrectly interprets it as `True`, causing:

```python
client.update_activity(activity_id, hide_from_home=False)
# Expected: hide_from_home should be False
# Actual: hide_from_home becomes True
```

## Solution

Remove the `int()` conversion and pass the boolean directly:

```python
# Before
params["hide_from_home"] = int(hide_from_home)

# After  
params["hide_from_home"] = hide_from_home
```

## Testing

User confirmed via HTTPie:
- ❌ `hide_from_home:=0` → sets to `true`
- ✅ `hide_from_home:=false` → sets to `false`

## Impact

This is a one-line fix that corrects the data type to match Strava API specification.

---

Fixes #716